### PR TITLE
Update git clone URL to use SSH instead of HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The easiest way to configure your Snowflake Landing Zone is using the **Answer F
 
 ```bash
 
-git clone https://github.com/Snowflake-Labs/snowflake-landing-zone.git
+git clone git@github.com:Snowflake-Labs/snowflake-landing-zone.git
 
 cd snowflake-landing-zone
 ```


### PR DESCRIPTION
Changed the clone URL in the README from HTTPS to SSH format for
developers who prefer SSH authentication.

.... Generated with [Cortex Code](https://docs.snowflake.com/user-guide/snowflake-cortex/cortex-agents)

Co-Authored-By: Cortex Code <noreply@snowflake.com>
