### PR TITLE
Add account setup triggers to answer-file-builder skill

### DIFF
--- a/.cortex/skills/answer-file-builder/SKILL.md
+++ b/.cortex/skills/answer-file-builder/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: answer-file-builder
-description: "Guide users through constructing answer files for Snowflake Blueprint Manager blueprints. Use when: user wants to create or complete an answer file, configure a blueprint, or understand configuration questions. Triggers: create answer file, build answers, configure blueprint, blueprint setup, fill out questionnaire, set up blueprint."
+description: "Guide users through constructing answer files for Snowflake Blueprint Manager blueprints. Use when: user wants to create or complete an answer file, configure a blueprint, or understand configuration questions. Triggers: create answer file, build answers, configure blueprint, blueprint setup, fill out questionnaire, set up blueprint, set up my first Snowflake account, create my environment, establish my platform, create my account following best practices, configure my snowflake organization, set up my snowflake environment, initialize my snowflake platform, snowflake account best practices."
 ---
 
 # Answer File Builder


### PR DESCRIPTION
## Summary
- Expanded skill description triggers to capture Snowflake account setup scenarios
- Added triggers for: "set up my first Snowflake account", "create my environment", "establish my platform", "create my account following best practices", "configure my snowflake organization", "set up my snowflake environment", "initialize my snowflake platform", "snowflake account best practices"

## Test plan
- [x] Verified skill file syntax is valid
- [x] Test skill invocation with new trigger phrases

.... Generated with [Cortex Code](https://docs.snowflake.com/user-guide/snowflake-cortex/cortex-agents)