### PR TITLE
[CXE-13841] Update generated file timestamp format to include hours, minutes, seconds

### DIFF
--- a/scripts/render_journey.py
+++ b/scripts/render_journey.py
@@ -546,7 +546,7 @@ def main():
     output_dir = base_dir / args.output_dir / args.lang
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    date_str = datetime.now().strftime("%Y%m%d")
+    date_str = datetime.now().strftime("%Y%m%d%H%M%S")
     extension = get_language_extension(args.lang)
     output_file = output_dir / f"{args.blueprint}_{date_str}.{extension}"
 


### PR DESCRIPTION
# PR Overview: CXE-13841

## Description & Motivation

This PR updates the generated sample answer file naming format to include hours, minutes, and seconds for improved granularity.

**Change**: Modified the timestamp format in the rendering script from `YYYYMMDD` to `YYYYMMDDHHmmss`.

- **Before**: `sample_answers_20260121`
- **After**: `sample_answers_20260121153045`

This change prevents filename collisions when multiple sample answer files are generated on the same day and provides better traceability for when files were created.

## Link to Ticket/Issue

- **JIRA**: [CXE-13841](https://snowflake.atlassian.net/browse/CXE-13841)

## Local Testing Performed

1. Ran the `render_journey.py` script to generate sample answer files
2. Verified the output filename includes the full timestamp with hours, minutes, and seconds
3. Confirmed the file content is unchanged and only the naming convention was updated

## How Reviewer Can Test

1. Checkout the branch
2. Run the rendering script:
   ```bash
   python scripts/render_journey.py --blueprint <blueprint_name> --lang <language> --output-dir <output_dir>
   ```
3. Verify the generated file follows the new naming pattern: `<blueprint>_YYYYMMDDHHmmss.<extension>`

## Config/Migration Steps

None required. This is a backward-compatible change that only affects newly generated files.

## Breaking Changes

None. Existing files are unaffected. Only new file generation uses the updated timestamp format.

## Screenshots/Recordings

N/A - This is a backend file naming change with no UI impact.
