### PR TITLE
[CXE-14134] [CXE-14134] Update render script for slug-based directory support

### DIFF
--- a/scripts/render_journey.py
+++ b/scripts/render_journey.py
@@ -205,6 +205,11 @@ def build_step_slug_map(blueprint_dir):
             continue
             
         # Add directory name as a key (slug-based lookup)
+        if child_dir.name in slug_map:
+            sys.stderr.write(
+                f"Warning: Duplicate step identifier '{child_dir.name}' - "
+                f"'{child_dir}' overwrites '{slug_map[child_dir.name]}'\n"
+            )
         slug_map[child_dir.name] = child_dir
         
         # Check for step metadata with additional identifiers
@@ -214,10 +219,22 @@ def build_step_slug_map(blueprint_dir):
                 step_meta = load_yaml(step_meta_file)
                 # Map step_id to directory path (for UID-based references)
                 if "step_id" in step_meta:
-                    slug_map[step_meta["step_id"]] = child_dir
+                    step_id = step_meta["step_id"]
+                    if step_id in slug_map and slug_map[step_id] != child_dir:
+                        sys.stderr.write(
+                            f"Warning: Duplicate step_id '{step_id}' - "
+                            f"'{child_dir}' overwrites '{slug_map[step_id]}'\n"
+                        )
+                    slug_map[step_id] = child_dir
                 # Map explicit slug if different from directory name
                 if "slug" in step_meta and step_meta["slug"] != child_dir.name:
-                    slug_map[step_meta["slug"]] = child_dir
+                    slug = step_meta["slug"]
+                    if slug in slug_map and slug_map[slug] != child_dir:
+                        sys.stderr.write(
+                            f"Warning: Duplicate slug '{slug}' - "
+                            f"'{child_dir}' overwrites '{slug_map[slug]}'\n"
+                        )
+                    slug_map[slug] = child_dir
             except yaml.YAMLError as e:
                 sys.stderr.write(f"Warning: Invalid YAML in {step_meta_file}: {e}\n")
             except (IOError, OSError) as e:


### PR DESCRIPTION
# PR Overview: Update Render Script for Slug-Based Directory Support

## Description

This PR modifies `render_journey.py` to support slug-based directory structures instead of UID-based directories, improving human readability of the GitHub file and directory structure in the blueprint-manager repository.

### Motivation

Currently, directories and files use randomly generated UIDs for uniqueness, which makes the structure difficult for humans to read and navigate. This also propagates into the CoCo experience as summaries and responses often reference these UIDs which are not easily understood by the user. The goal is to transition to slug-based naming while maintaining uniqueness.

### Changes Made

1. **New Helper Functions**:
   - `get_blueprint_slug()`: Retrieves the slug for a blueprint from meta.yaml or directory name
   - `resolve_step_path()`: Resolves step identifiers to actual directory paths with slug-based and UID fallback support
   - `build_step_slug_map()`: Builds a mapping of step identifiers to directory paths for efficient lookups

2. **Updated `render_blueprint_code()` Function**:
   - Uses slug-based path resolution for steps
   - Updated header comments to reference blueprint slug instead of UID
   - Error messages and skip notes now reference human-readable slugs

3. **Updated `render_blueprint_guidance()` Function**:
   - Applies the same slug-based path resolution as code rendering
   - Updated headers and step references to use slugs

4. **Updated Blueprint Directory Lookup in `main()`**:
   - Supports both slug-based and legacy UID-based blueprint lookups
   - Searches meta.yaml files for matching blueprint_id or slug when direct lookup fails
   - Lists available blueprints with their names when a blueprint is not found

5. **Updated Output File Naming**:
   - Changed from `{blueprint}_{timestamp}.{ext}` to `{slug}_{YYYYMMDD}.{ext}`
   - Example: `account-creation_20260205.sql` instead of `abc123uid_20260205143022.sql`

6. **Backwards Compatibility**:
   - Fallback support for legacy UID-based paths during transition period
   - Logs a note when using legacy UID-based paths to help track migration progress

## Related Issues

- **JIRA Ticket**: [CXE-14134](https://snowflakecomputing.atlassian.net/browse/CXE-14134) - Update Render Script for Slug Support
- **Parent Epic**: [CXE-13972](https://snowflakecomputing.atlassian.net/browse/CXE-13972) - Improve human readability of the GitHub file and directory structure

## Local Testing Performed

1. Verified script successfully renders blueprints using slug-based directory structure
2. Confirmed output files are named with slugs (e.g., `account-creation_20260205.sql`)
3. Tested error messages reference slugs for better user experience
4. Validated backwards compatibility with UID-based structures using fallback logic
5. Tested blueprint lookup with both slug and legacy UID identifiers

## How to Test

1. Clone the repository and checkout this branch
2. Run the render script with a slug-based blueprint:
   ```bash
   python scripts/render_journey.py <blueprint-slug> --lang sql --answers <answers-file.yaml>
   ```
3. Verify the output file is named with the slug (e.g., `blueprint-slug_20260209.sql`)
4. Test with a legacy UID-based blueprint to verify fallback works:
   ```bash
   python scripts/render_journey.py <legacy-uid> --lang sql --answers <answers-file.yaml>
   ```
5. Verify error messages display human-readable slugs when steps are missing

## Configuration/Migration Steps

- No configuration changes required
- No database migrations needed
- Existing UID-based blueprints will continue to work via fallback mechanism
- As blueprints are migrated to slug-based naming, the fallback will log notes to stderr to track progress

## Breaking Changes

None. This change is backwards compatible:
- Existing UID-based directory structures continue to work via fallback
- Output file naming format changed from timestamp with seconds to date only, but this is a non-breaking change for downstream consumers

## Screenshots/Recordings

N/A - This is a backend script change with no UI components.
