### PR TITLE
CXE-14255: Update Blueprint Builder skill with task context awareness

### DIFF
--- a/.cortex/skills/blueprint-builder/SKILL.md
+++ b/.cortex/skills/blueprint-builder/SKILL.md
@@ -788,7 +788,7 @@ When a user asks "how much is left?", "what's my progress?", "how far along am I
 2. Present the response:
 
 ```
-**Current Task:** [Task Title] — [completed]/[total] steps ([percentage]%)
+**Current Task:** [Task Title] — [completed_steps_in_task]/[total_steps_in_task] steps ([percentage]%)
 
 **Overall Blueprint Progress:** [completed_steps]/[total_steps] steps ([percentage]%)
   - Completed tasks: [completed_tasks]/[total_tasks]
@@ -830,9 +830,9 @@ When a user returns to an in-progress blueprint (e.g., they resume a previous se
 
 ---
 
-**Current Step:** Step [N]: [Step Title]
+**Current Step:** Step [N of M]: [Step Title]
 
-**Task Progress:** [completed_steps]/[total_steps_in_task] steps complete ([percentage]%)
+**Task Progress:** [completed_steps_in_task]/[total_steps_in_task] steps complete ([percentage]%)
 
 **Remaining steps in this task:**
 1. [Remaining step title]


### PR DESCRIPTION
## Description

Update the Blueprint Builder skill (`.cortex/skills/blueprint-builder/SKILL.md`) to leverage task-level context from structured YAML task files. Previously, the skill had no awareness of task boundaries, personas, or prerequisites. This change adds four capabilities:

1. **Task Overview Display at Task Boundaries** — When a user begins the first step of a new task, the skill now displays a structured overview including what they will accomplish (from `summary`), prerequisites (from `role_requirements` and `external_requirements`), and who should be involved (from `personas`).

2. **Navigation Support Using Task Context** — The skill can now answer "what's next?" or "how much is left?" by showing the current task/step position, remaining steps in the task, and overall blueprint progress.

3. **Question Grouping by Task for Persona/Role Routing** — Questions are grouped by their parent task's `personas` field during both step-by-step walkthrough and configuration summary. This enables routing answers to the right teams (e.g., "The following questions are for your Security Administrator to review").

4. **Context Recovery for In-Progress Work** — When a user resumes a partially-completed blueprint, the skill now shows the current task's full overview, a list of previously completed tasks with summaries, remaining steps, and overall progress.

### Motivation

The parent ticket (CXE-13598) established that task YAML files contain structured metadata (`summary`, `personas`, `role_requirements`, `external_requirements`, `description`) that was not being utilized by the skill. This change closes the gap so users get better orientation, navigation, and organizational routing during blueprint walkthroughs.

## Linked Ticket

[CXE-14255: Update Blueprint Builder Skill for Task Context](https://snowflakecomputing.atlassian.net/browse/CXE-14255)

Parent: [CXE-13598: Determine how to incorporate task overview content](https://snowflakecomputing.atlassian.net/browse/CXE-13598)

## Local Testing Performed

- Reviewed the modified SKILL.md to verify all four acceptance criteria are addressed:
  - Task overview display at boundaries (new Step 7.0)
  - Navigation support with task context (enhanced context recovery section)
  - Question grouping by persona for routing (new "Question Grouping by Task for Persona/Role Routing" section)
  - Context recovery for in-progress work (enhanced recovery summary with task overview, completed tasks, and overall progress)
- Verified the instructions reference the correct task metadata fields (`summary`, `personas`, `role_requirements`, `external_requirements`)
- Verified the instructions reference the correct file paths (`blueprints/<blueprint_id>/tasks/<task_slug>.md`)
- Confirmed no changes to task YAML schema or sync scripts (out of scope per ticket)

## How to Test

1. Open Cortex Code in a repository that has the Blueprint Builder skill
2. Start a blueprint walkthrough and verify that when entering the first step of a new task, a task overview is displayed with summary, prerequisites, and personas
3. Ask "what's next?" or "how much is left?" mid-walkthrough and verify the skill responds with task-aware progress
4. Complete some steps and then start a new session — verify the skill shows a context recovery summary with the current task overview, previously completed tasks, and remaining steps
5. Review the configuration summary (Step 6) and verify answers are grouped by task with persona annotations

## Configuration / Migration Steps

None. This is a skill instruction change only — no schema changes, no new dependencies, no database migrations.

## Breaking Changes

None. The changes are additive instructions within the existing SKILL.md. Existing walkthrough behavior is preserved; the new task context features layer on top of the existing step-by-step flow.
