### PR TITLE
Add license headers to skills, commands, and scripts

### DIFF
--- a/.cortex/commands/blueprints.md
+++ b/.cortex/commands/blueprints.md
@@ -1,3 +1,6 @@
+<!-- Copyright (c) 2026 Snowflake Inc. All rights reserved.
+     Licensed under the Snowflake Skills License. See LICENSE file. -->
+
 # Blueprints Command
 
 Manage Snowflake blueprints, projects, and answer files.

--- a/.cortex/commands/blueprints/answers/diff.md
+++ b/.cortex/commands/blueprints/answers/diff.md
@@ -1,3 +1,6 @@
+<!-- Copyright (c) 2026 Snowflake Inc. All rights reserved.
+     Licensed under the Snowflake Skills License. See LICENSE file. -->
+
 # Blueprints Answers Diff
 
 Compare two answer files to show differences.

--- a/.cortex/commands/blueprints/answers/init.md
+++ b/.cortex/commands/blueprints/answers/init.md
@@ -1,3 +1,6 @@
+<!-- Copyright (c) 2026 Snowflake Inc. All rights reserved.
+     Licensed under the Snowflake Skills License. See LICENSE file. -->
+
 # Blueprints Answers Init
 
 Generate a skeleton answer file with all questions for a blueprint.

--- a/.cortex/commands/blueprints/answers/validate.md
+++ b/.cortex/commands/blueprints/answers/validate.md
@@ -1,3 +1,6 @@
+<!-- Copyright (c) 2026 Snowflake Inc. All rights reserved.
+     Licensed under the Snowflake Skills License. See LICENSE file. -->
+
 # Blueprints Answers Validate
 
 Check an answer file for missing or invalid values without needing to specify a blueprint.

--- a/.cortex/commands/blueprints/build.md
+++ b/.cortex/commands/blueprints/build.md
@@ -1,3 +1,6 @@
+<!-- Copyright (c) 2026 Snowflake Inc. All rights reserved.
+     Licensed under the Snowflake Skills License. See LICENSE file. -->
+
 # Blueprints Build
 
 Start the interactive blueprint building process. This command wraps the `blueprint-builder` skill to guide users through creating a complete answer file for a blueprint.

--- a/.cortex/commands/blueprints/describe.md
+++ b/.cortex/commands/blueprints/describe.md
@@ -1,3 +1,6 @@
+<!-- Copyright (c) 2026 Snowflake Inc. All rights reserved.
+     Licensed under the Snowflake Skills License. See LICENSE file. -->
+
 # Blueprints Describe
 
 Show detailed information about a specific blueprint, including its task/step tree.

--- a/.cortex/commands/blueprints/list.md
+++ b/.cortex/commands/blueprints/list.md
@@ -1,3 +1,6 @@
+<!-- Copyright (c) 2026 Snowflake Inc. All rights reserved.
+     Licensed under the Snowflake Skills License. See LICENSE file. -->
+
 # Blueprints List
 
 List all available blueprints with their metadata.

--- a/.cortex/commands/blueprints/projects/create.md
+++ b/.cortex/commands/blueprints/projects/create.md
@@ -1,3 +1,6 @@
+<!-- Copyright (c) 2026 Snowflake Inc. All rights reserved.
+     Licensed under the Snowflake Skills License. See LICENSE file. -->
+
 # Blueprints Projects Create
 
 Create a new project directory structure for organizing blueprint work.

--- a/.cortex/commands/blueprints/projects/describe.md
+++ b/.cortex/commands/blueprints/projects/describe.md
@@ -1,3 +1,6 @@
+<!-- Copyright (c) 2026 Snowflake Inc. All rights reserved.
+     Licensed under the Snowflake Skills License. See LICENSE file. -->
+
 # Blueprints Projects Describe
 
 Show detailed status of a project, including answer files, outputs, and history.

--- a/.cortex/commands/blueprints/projects/list.md
+++ b/.cortex/commands/blueprints/projects/list.md
@@ -1,3 +1,6 @@
+<!-- Copyright (c) 2026 Snowflake Inc. All rights reserved.
+     Licensed under the Snowflake Skills License. See LICENSE file. -->
+
 # Blueprints Projects List
 
 List all existing projects in the blueprint-manager workspace.

--- a/.cortex/commands/blueprints/render.md
+++ b/.cortex/commands/blueprints/render.md
@@ -1,3 +1,6 @@
+<!-- Copyright (c) 2026 Snowflake Inc. All rights reserved.
+     Licensed under the Snowflake Skills License. See LICENSE file. -->
+
 # Blueprints Render
 
 Generate SQL/Terraform/Documentation from an answer file. This command wraps the `render_journey.py` script.

--- a/.cortex/commands/blueprints/validate.md
+++ b/.cortex/commands/blueprints/validate.md
@@ -1,3 +1,6 @@
+<!-- Copyright (c) 2026 Snowflake Inc. All rights reserved.
+     Licensed under the Snowflake Skills License. See LICENSE file. -->
+
 # Blueprints Validate
 
 Check an answer file for completeness against blueprint requirements and validate blueprint schema.

--- a/.cortex/skills/blueprint-builder/SKILL.md
+++ b/.cortex/skills/blueprint-builder/SKILL.md
@@ -1,3 +1,6 @@
+<!-- Copyright (c) 2026 Snowflake Inc. All rights reserved.
+     Licensed under the Snowflake Skills License. See LICENSE file. -->
+
 ---
 name: blueprint-builder
 description: "Guide users through constructing answer files for Snowflake Blueprint Manager blueprints. Use when: user wants to create or complete an answer file, configure a blueprint, or understand configuration questions. Triggers: create blueprint, build blueprint, configure blueprint, blueprint setup, fill out questionnaire, set up blueprint, set up my first Snowflake account, create my environment, establish my platform, create my account following best practices, configure my snowflake organization, set up my snowflake environment, initialize my snowflake platform, snowflake account best practices."

--- a/.cortex/skills/snowflake-best-practices/SKILL.md
+++ b/.cortex/skills/snowflake-best-practices/SKILL.md
@@ -1,3 +1,6 @@
+<!-- Copyright (c) 2026 Snowflake Inc. All rights reserved.
+     Licensed under the Snowflake Skills License. See LICENSE file. -->
+
 ---
 name: snowflake-best-practices
 description: "Snowflake best practices, guidance, recommendations, setup, and configuration advice curated by Snowflake subject matter experts. Use when: user asks about Snowflake best practices, setup recommendations, configuration guidance, architecture decisions, security patterns, cost management, RBAC design, account strategy, naming conventions, or how to implement Snowflake features correctly. Triggers: best practice, recommendation, guidance, how should I, what's the best way, setup advice, configuration help, Snowflake architecture, blueprint."

--- a/README.md
+++ b/README.md
@@ -316,5 +316,5 @@ python scripts/render_journey.py \
 Review the generated SQL file, then execute it in your Snowflake worksheet. The SQL is idempotent — safe to run multiple times.
 
 License
-Copyright (c) Snowflake Inc. All rights reserved.
+Copyright (c) 2026 Snowflake Inc. All rights reserved.
 This repo is source-available and licensed under these [terms](/LICENSE).

--- a/scripts/render_journey.py
+++ b/scripts/render_journey.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+
+# Copyright (c) 2026 Snowflake Inc. All rights reserved.
+# Licensed under the Snowflake Skills License. See LICENSE file.
+
 """
 render_journey.py
 

--- a/scripts/test_render_journey.py
+++ b/scripts/test_render_journey.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+
+# Copyright (c) 2026 Snowflake Inc. All rights reserved.
+# Licensed under the Snowflake Skills License. See LICENSE file.
+
 """
 Unit tests for render_journey.py
 


### PR DESCRIPTION
## Summary
- Adds copyright and license headers to all `.md` command/skill files (HTML comment format) and `.py` scripts (Python comment format)
- Updates `README.md` license line to include the year (2026)
- 17 files updated across `.cortex/commands/`, `.cortex/skills/`, `scripts/`, and `README.md`

## Test plan
- [ ] Verify license headers render correctly (HTML comments should be invisible in rendered markdown)
- [ ] Confirm `render_journey.py` and `test_render_journey.py` still execute without issues
- [ ] Spot-check that SKILL.md frontmatter is still parsed correctly (header is before the `---` block)

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)