### PR TITLE
CXE-14502: Fix imports, variable shadowing, and remove dead code in render_journey.py

### DIFF
--- a/scripts/render_journey.py
+++ b/scripts/render_journey.py
@@ -836,9 +836,9 @@ def render_blueprint_code(blueprint_dir, lang, answers, base_dir, task_context=N
         )
         sys.exit(1)
 
-    meta = load_yaml(meta_file)
-    blueprint_name = meta.get("name", blueprint_id)
-    step_order = meta.get("steps", [])
+    blueprint_meta = load_yaml(meta_file)
+    blueprint_name = blueprint_meta.get("name", blueprint_id)
+    step_order = blueprint_meta.get("steps", [])
 
     # Create Jinja2 environment once for all steps
     jinja_env = Environment(
@@ -1030,10 +1030,10 @@ def render_blueprint_guidance(blueprint_dir, answers, base_dir, task_context=Non
         )
         sys.exit(1)
 
-    meta = load_yaml(meta_file)
-    blueprint_name = meta.get("name", blueprint_id)
-    blueprint_overview = meta.get("overview", "")
-    step_order = meta.get("steps", [])
+    blueprint_meta = load_yaml(meta_file)
+    blueprint_name = blueprint_meta.get("name", blueprint_id)
+    blueprint_overview = blueprint_meta.get("overview", "")
+    step_order = blueprint_meta.get("steps", [])
 
     # Create Jinja2 environment with strict undefined checking
     jinja_env = Environment(


### PR DESCRIPTION
# CXE-14502: Quick Fixes -- Imports, Shadowing, Dead Code

## Description

Mechanical cleanup of `scripts/render_journey.py` addressing findings from the repo quality audit (CXE-14437). These are pure structural changes with **no behavioral impact** -- the script's output for any input remains identical.

**Changes:**

1. **Consolidate imports** -- Moved three inline `import re` statements and one inline `from jinja2 import UndefinedError` to the top-level import block. Removed unused `meta` and `nodes` from the jinja2 import.
2. **Promote `NullTracker` to module level** -- Extracted the class from inside `check_template_renderable` to module scope (it has no closure over function locals).
3. **Fix `step_id` variable shadowing** -- In `render_blueprint_code` and `render_blueprint_guidance`, the return value from `render_step_code`/`render_step_guidance` was silently overwriting the loop iterator `step_id`. Replaced with `_` since the returned value is always identical to the loop variable.
4. **Rename `meta` -> `blueprint_meta`** -- Local variable `meta` in `load_task_metadata`, `render_blueprint_code`, and `render_blueprint_guidance` shadowed the `jinja2.meta` module import. Renamed to `blueprint_meta`.
5. **Remove dead code** -- Deleted `find_template_variables` and `find_template_set_variables` (never called anywhere in the codebase).
6. **Remove redundant f-strings** -- `f"{step_title}"` replaced with `step_title` in two places in `render_blueprint_guidance`.
7. **Remove dead CLI arguments** -- Deleted `--output-dir` and `--guidance-dir` from `parse_args` and their associated warning logic in `main`. These paths are already derived from `project_dir`.
8. **Extract `DEFAULT_PROJECT_NAME` constant** -- Replaced the inline `"default-project"` string literal with a module-level constant.

**Audit refs addressed:** 1.1, 3.2, 5.1, 5.2, 5.3, 5.4, 5.5, 5.6, 6.2

## Ticket

[CXE-14502](https://snowflakecomputing.atlassian.net/browse/CXE-14502) (parent: [CXE-14437](https://snowflakecomputing.atlassian.net/browse/CXE-14437))

## Local Testing

- `python -m py_compile scripts/render_journey.py` -- compiles without errors.
- `python scripts/test_render_journey.py` -- all existing tests pass unchanged.
- Verified `find_template_variables` and `find_template_set_variables` have zero references in the codebase.
- Verified no `import re` statements remain inside function bodies.
- Verified no references to `args.output_dir` or `args.guidance_dir` remain.

## How to Review/Test

1. **Compile check:** `python -m py_compile scripts/render_journey.py`
2. **Run tests:** `python scripts/test_render_journey.py` -- all 13 test classes should pass with no modifications.
3. **Grep for removed dead code:** `grep -rn "find_template_variables\|find_template_set_variables" scripts/` -- should return zero hits.
4. **Grep for inline imports:** `grep -n "import re" scripts/render_journey.py` -- should show only the single top-level import.
5. **Verify no behavioral change:** The diff is purely mechanical. No logic, control flow, or output has changed.

## Config/Migration Steps

None. No configuration changes, no new dependencies, no migration needed.

## Breaking Changes

None. All changes are internal to `scripts/render_journey.py`. The two removed CLI arguments (`--output-dir`, `--guidance-dir`) were already non-functional (ignored with a warning), so removing them has no practical impact.
