### PR TITLE
CXE-14504: Eliminate double-rendering and unify step template rendering

### DIFF
--- a/scripts/render_journey.py
+++ b/scripts/render_journey.py
@@ -657,10 +657,18 @@ def get_step_title(step_path):
     return None
 
 
-def check_template_renderable(template_path, answers, jinja_env, base_dir):
+def create_jinja_env(base_dir):
+    """Create a Jinja2 environment configured for blueprint template rendering."""
+    return Environment(
+        loader=FileSystemLoader(base_dir),
+        undefined=StrictUndefined,
+        keep_trailing_newline=True,
+    )
+
+
+def try_render_template(template_path, answers, jinja_env, base_dir):
     """
-    Check if a template can be rendered with the given answers by attempting
-    to render it and catching any UndefinedError exceptions.
+    Attempt to render a Jinja2 template with the given answers.
 
     This approach correctly handles conditional logic - variables that are only
     used inside conditional blocks that won't execute (based on current answer
@@ -671,8 +679,8 @@ def check_template_renderable(template_path, answers, jinja_env, base_dir):
     in the active code path, users may need to fix them one at a time.
     This is a tradeoff for correctly handling conditional logic.
 
-    Returns tuple: (can_render, missing_vars, null_vars)
-    - can_render: True if template can be safely rendered
+    Returns tuple: (rendered_output, missing_vars, null_vars)
+    - rendered_output: the rendered string on success, or None on failure
     - missing_vars: list of variables that are actually needed but not in answers
     - null_vars: list of variables that are actually needed but are None in answers
     """
@@ -689,10 +697,10 @@ def check_template_renderable(template_path, answers, jinja_env, base_dir):
                 render_context[key] = value
 
         # Attempt to render
-        template.render(**render_context)
+        rendered_output = template.render(**render_context)
 
         # If we get here, template rendered successfully
-        return True, [], []
+        return rendered_output, [], []
 
     except UndefinedError as e:
         # Extract variable name from error message
@@ -714,34 +722,58 @@ def check_template_renderable(template_path, answers, jinja_env, base_dir):
             # Fallback: couldn't parse, include raw error
             missing_vars.append(error_msg)
 
-        return False, sorted(missing_vars), sorted(null_vars)
+        return None, sorted(missing_vars), sorted(null_vars)
 
     except TemplateError as e:
         # Other template errors (syntax, etc.) - can't render
         # Return the error message so users can diagnose issues
-        return False, [f"Template error: {str(e)}"], []
+        return None, [f"Template error: {str(e)}"], []
 
 
-def render_step_code(step_path, lang, answers, jinja_env, base_dir):
+def check_template_renderable(template_path, answers, jinja_env, base_dir):
     """
-    Render code template for a step.
-    Returns tuple: (rendered_code, step_id, missing_vars)
-    - rendered_code: the rendered content or None if file doesn't exist
-    - step_id: the step identifier
+    Check if a template can be rendered with the given answers.
+
+    Thin wrapper around try_render_template that returns a boolean instead of
+    the rendered output. Used in render_blueprint_guidance's pre-scan phase
+    where only the renderability check is needed.
+
+    Returns tuple: (can_render, missing_vars, null_vars)
+    - can_render: True if template can be safely rendered
+    - missing_vars: list of variables that are actually needed but not in answers
+    - null_vars: list of variables that are actually needed but are None in answers
+    """
+    output, missing, null = try_render_template(template_path, answers, jinja_env, base_dir)
+    return (output is not None), missing, null
+
+
+def render_step_template(step_path, template_name, answers, jinja_env, base_dir):
+    """
+    Render a single template file within a step directory.
+
+    Args:
+        step_path: Path to the step directory
+        template_name: Name of the template file (e.g., "code.sql.jinja", "dynamic.md.jinja")
+        answers: Dictionary of user-provided answers
+        jinja_env: Configured Jinja2 Environment
+        base_dir: Base directory for template loading
+
+    Returns tuple: (rendered_content, step_id, missing_vars)
+    - rendered_content: the rendered string, or None if file doesn't exist or can't render
+    - step_id: the step identifier (step_path.name)
     - missing_vars: list of missing/null variable names (empty if successful)
     """
     step_id = step_path.name
-    code_file = step_path / f"code.{lang}.jinja"
+    template_file = step_path / template_name
 
-    if not code_file.exists():
+    if not template_file.exists():
         return None, step_id, []
 
-    # Check if template can be rendered by attempting actual rendering
-    # This correctly handles conditional logic - variables only used in inactive branches won't cause skips
-    can_render, missing_vars, null_vars = check_template_renderable(
-        code_file, answers, jinja_env, base_dir
+    rendered, missing_vars, null_vars = try_render_template(
+        template_file, answers, jinja_env, base_dir
     )
-    if not can_render:
+
+    if rendered is None:
         all_issues = missing_vars + null_vars
         issue_details = []
         if missing_vars:
@@ -749,65 +781,11 @@ def render_step_code(step_path, lang, answers, jinja_env, base_dir):
         if null_vars:
             issue_details.append(f"null values {null_vars}")
         sys.stderr.write(
-            f"  Skipping {step_id}/code.{lang}.jinja: {', '.join(issue_details)}\n"
+            f"  Skipping {step_id}/{template_name}: {', '.join(issue_details)}\n"
         )
         return None, step_id, all_issues
 
-    try:
-        # Load template using the shared Jinja2 environment
-        template = jinja_env.get_template(str(code_file.relative_to(base_dir)))
-
-        # Render the template (pre-check should have caught issues)
-        rendered = template.render(**answers)
-        return rendered, step_id, []
-
-    except TemplateError as e:
-        sys.stderr.write(f"Warning: Template error in {code_file}: {e}\n")
-        return None, step_id, []
-
-
-def render_step_guidance(step_path, answers, jinja_env, base_dir):
-    """
-    Render dynamic guidance markdown for a step from dynamic.md.jinja.
-    Returns tuple: (rendered_content, step_id, missing_vars)
-    - rendered_content: the rendered content or None if file doesn't exist
-    - step_id: the step identifier
-    - missing_vars: list of missing variable names (empty if successful)
-    """
-    step_id = step_path.name
-    dynamic_file = step_path / "dynamic.md.jinja"
-
-    if not dynamic_file.exists():
-        return None, step_id, []
-
-    # Check if template can be rendered by attempting actual rendering
-    # This correctly handles conditional logic - variables only used in inactive branches won't cause skips
-    can_render, missing_vars, null_vars = check_template_renderable(
-        dynamic_file, answers, jinja_env, base_dir
-    )
-    if not can_render:
-        all_issues = missing_vars + null_vars
-        issue_details = []
-        if missing_vars:
-            issue_details.append(f"missing {missing_vars}")
-        if null_vars:
-            issue_details.append(f"null values {null_vars}")
-        sys.stderr.write(
-            f"  Skipping {step_id}/dynamic.md.jinja: {', '.join(issue_details)}\n"
-        )
-        return None, step_id, all_issues
-
-    try:
-        # Load template using the shared Jinja2 environment
-        template = jinja_env.get_template(str(dynamic_file.relative_to(base_dir)))
-
-        # Render the template (pre-check should have caught issues)
-        rendered = template.render(**answers)
-        return rendered, step_id, []
-
-    except TemplateError as e:
-        sys.stderr.write(f"Warning: Template error in {dynamic_file}: {e}\n")
-        return None, step_id, []
+    return rendered, step_id, []
 
 
 def render_blueprint_code(blueprint_dir, lang, answers, base_dir, task_context=None):
@@ -846,11 +824,7 @@ def render_blueprint_code(blueprint_dir, lang, answers, base_dir, task_context=N
     step_order = blueprint_meta.get("steps", [])
 
     # Create Jinja2 environment once for all steps
-    jinja_env = Environment(
-        loader=FileSystemLoader(base_dir),
-        undefined=StrictUndefined,
-        keep_trailing_newline=True,
-    )
+    jinja_env = create_jinja_env(base_dir)
 
     comment_char = get_comment_syntax(lang)
     rendered_sections = []
@@ -927,8 +901,8 @@ def render_blueprint_code(blueprint_dir, lang, answers, base_dir, task_context=N
             sys.stderr.write(f"Warning: Step directory not found: {step_path}\n")
             continue
 
-        rendered_code, _, missing_vars = render_step_code(
-            step_path, lang, answers, jinja_env, base_dir
+        rendered_code, _, missing_vars = render_step_template(
+            step_path, f"code.{lang}.jinja", answers, jinja_env, base_dir
         )
 
         # Determine step numbering (hierarchical if task context available, flat otherwise)
@@ -1042,11 +1016,7 @@ def render_blueprint_guidance(blueprint_dir, answers, base_dir, task_context=Non
     step_order = blueprint_meta.get("steps", [])
 
     # Create Jinja2 environment with strict undefined checking
-    jinja_env = Environment(
-        loader=FileSystemLoader(base_dir),
-        undefined=StrictUndefined,
-        keep_trailing_newline=True,
-    )
+    jinja_env = create_jinja_env(base_dir)
 
     # Extract task context if provided
     step_mapping = task_context.get("step_mapping", {}) if task_context else {}
@@ -1172,8 +1142,8 @@ def render_blueprint_guidance(blueprint_dir, answers, base_dir, task_context=Non
             sys.stderr.write(f"Warning: Step directory not found: {step_path}\n")
             continue
 
-        rendered_guidance, _, missing_vars = render_step_guidance(
-            step_path, answers, jinja_env, base_dir
+        rendered_guidance, _, missing_vars = render_step_template(
+            step_path, "dynamic.md.jinja", answers, jinja_env, base_dir
         )
 
         # Determine step numbering (hierarchical if task context available, flat otherwise)

--- a/scripts/test_render_journey.py
+++ b/scripts/test_render_journey.py
@@ -18,12 +18,11 @@ from pathlib import Path
 from unittest import TestCase, main
 
 import yaml
-from jinja2 import Environment, FileSystemLoader, StrictUndefined
 
 # Add the scripts directory to path
 sys.path.insert(0, str(Path(__file__).parent))
 
-from render_journey import check_template_renderable
+from render_journey import check_template_renderable, create_jinja_env
 
 
 class TestConditionalVariableHandling(TestCase):
@@ -33,11 +32,7 @@ class TestConditionalVariableHandling(TestCase):
         """Create a temporary directory structure for test templates."""
         self.temp_dir = tempfile.mkdtemp()
         self.base_dir = Path(self.temp_dir)
-        self.jinja_env = Environment(
-            loader=FileSystemLoader(self.base_dir),
-            undefined=StrictUndefined,
-            keep_trailing_newline=True,
-        )
+        self.jinja_env = create_jinja_env(self.base_dir)
 
     def tearDown(self):
         """Clean up temporary directories."""
@@ -269,11 +264,7 @@ class TestMultipleConditionalPatterns(TestCase):
         """Create a temporary directory structure for test templates."""
         self.temp_dir = tempfile.mkdtemp()
         self.base_dir = Path(self.temp_dir)
-        self.jinja_env = Environment(
-            loader=FileSystemLoader(self.base_dir),
-            undefined=StrictUndefined,
-            keep_trailing_newline=True,
-        )
+        self.jinja_env = create_jinja_env(self.base_dir)
 
     def tearDown(self):
         """Clean up temporary directories."""
@@ -362,11 +353,7 @@ class TestNullTrackerEdgeCases(TestCase):
         """Create a temporary directory structure for test templates."""
         self.temp_dir = tempfile.mkdtemp()
         self.base_dir = Path(self.temp_dir)
-        self.jinja_env = Environment(
-            loader=FileSystemLoader(self.base_dir),
-            undefined=StrictUndefined,
-            keep_trailing_newline=True,
-        )
+        self.jinja_env = create_jinja_env(self.base_dir)
 
     def tearDown(self):
         """Clean up temporary directories."""
@@ -506,11 +493,7 @@ class TestNullTrackerComparisonOperators(TestCase):
         """Create a temporary directory structure for test templates."""
         self.temp_dir = tempfile.mkdtemp()
         self.base_dir = Path(self.temp_dir)
-        self.jinja_env = Environment(
-            loader=FileSystemLoader(self.base_dir),
-            undefined=StrictUndefined,
-            keep_trailing_newline=True,
-        )
+        self.jinja_env = create_jinja_env(self.base_dir)
 
     def tearDown(self):
         """Clean up temporary directories."""
@@ -1622,6 +1605,102 @@ class TestGetTaskProgress(TestCase):
         self.assertEqual(progress["current_task"]["total_steps"], 1)
         self.assertEqual(progress["current_task"]["completion_percentage"], 100.0)
         self.assertEqual(progress["blueprint"]["completion_percentage"], 100.0)
+
+
+class TestRenderStepTemplate(TestCase):
+    """Test render_step_template() unified step rendering (CXE-14504)."""
+
+    def setUp(self):
+        """Create a temporary directory structure for test templates."""
+        self.temp_dir = tempfile.mkdtemp()
+        self.base_dir = Path(self.temp_dir)
+        self.jinja_env = create_jinja_env(self.base_dir)
+
+        # Create a step directory
+        self.step_path = self.base_dir / "test-step"
+        self.step_path.mkdir(parents=True)
+
+    def tearDown(self):
+        """Clean up temporary directories."""
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def create_template(self, name, content):
+        """Create a test template file inside the step directory."""
+        template_path = self.step_path / name
+        template_path.write_text(content)
+        return template_path
+
+    def test_template_not_exists_returns_none(self):
+        """Non-existent template file should return (None, step_id, [])."""
+        from render_journey import render_step_template
+
+        rendered, step_id, missing = render_step_template(
+            self.step_path, "code.sql.jinja", {}, self.jinja_env, self.base_dir
+        )
+
+        self.assertIsNone(rendered)
+        self.assertEqual(step_id, "test-step")
+        self.assertEqual(missing, [])
+
+    def test_successful_render(self):
+        """Template with all variables present should render successfully."""
+        from render_journey import render_step_template
+
+        self.create_template("code.sql.jinja", "SELECT '{{ name }}';")
+        rendered, step_id, missing = render_step_template(
+            self.step_path, "code.sql.jinja", {"name": "Alice"}, self.jinja_env, self.base_dir
+        )
+
+        self.assertEqual(rendered, "SELECT 'Alice';")
+        self.assertEqual(step_id, "test-step")
+        self.assertEqual(missing, [])
+
+    def test_missing_variable_returns_none(self):
+        """Template with missing variable should return (None, step_id, [var])."""
+        from render_journey import render_step_template
+
+        self.create_template("code.sql.jinja", "SELECT '{{ name }}';")
+        rendered, step_id, missing = render_step_template(
+            self.step_path, "code.sql.jinja", {}, self.jinja_env, self.base_dir
+        )
+
+        self.assertIsNone(rendered)
+        self.assertEqual(step_id, "test-step")
+        self.assertIn("name", missing)
+
+    def test_null_variable_in_active_branch_returns_none(self):
+        """Null variable used in active branch should return (None, step_id, [var])."""
+        from render_journey import render_step_template
+
+        self.create_template("dynamic.md.jinja", "Hello {{ user }}!")
+        rendered, step_id, missing = render_step_template(
+            self.step_path, "dynamic.md.jinja", {"user": None}, self.jinja_env, self.base_dir
+        )
+
+        self.assertIsNone(rendered)
+        self.assertEqual(step_id, "test-step")
+        self.assertIn("user", missing)
+
+    def test_null_variable_in_inactive_branch_renders(self):
+        """Null variable in inactive conditional branch should render successfully."""
+        from render_journey import render_step_template
+
+        self.create_template(
+            "dynamic.md.jinja",
+            """{% if use_feature %}Feature: {{ feature_config }}{% else %}No feature{% endif %}""",
+        )
+        rendered, step_id, missing = render_step_template(
+            self.step_path,
+            "dynamic.md.jinja",
+            {"use_feature": False, "feature_config": None},
+            self.jinja_env,
+            self.base_dir,
+        )
+
+        self.assertIsNotNone(rendered)
+        self.assertIn("No feature", rendered)
+        self.assertEqual(step_id, "test-step")
+        self.assertEqual(missing, [])
 
 
 class TestValidateName(TestCase):


### PR DESCRIPTION
## Description

Eliminates double-rendering and unifies duplicated step template rendering in `scripts/render_journey.py`.

Previously, every renderable template was rendered **twice**: once by `check_template_renderable` (to verify renderability) and again by `render_step_code` / `render_step_guidance` (to produce the actual output). This was wasteful and introduced a TOCTOU inconsistency. Additionally, `render_step_code` and `render_step_guidance` were near-identical ~40-line functions differing only in the template filename and log prefix, and the `Environment(...)` constructor was duplicated in three locations.

This PR addresses audit findings 1.3, 2.1, and 2.6 from the parent ticket's code audit:

1. **Refactored `check_template_renderable` into `try_render_template`** -- returns the rendered output on success (`rendered_string, [], []`) instead of just a boolean (`True, [], []`), and `None` on failure instead of `False`. A thin `check_template_renderable` wrapper is preserved for backward compatibility (used in `render_blueprint_guidance`'s pre-scan phase).

2. **Replaced `render_step_code` and `render_step_guidance` with a single `render_step_template`** -- a unified function parameterized by `template_name` that delegates to `try_render_template`, eliminating the second render pass and removing ~40 lines of duplicated logic.

3. **Extracted `create_jinja_env(base_dir)` factory function** -- replaces three identical `Environment(loader=FileSystemLoader(...), undefined=StrictUndefined, keep_trailing_newline=True)` constructions in `render_blueprint_code`, `render_blueprint_guidance`, and all test `setUp` methods.

4. **Added `TestRenderStepTemplate` test class** with 5 test cases covering: template not found, successful render, missing variable, null variable in active branch, and null variable in inactive conditional branch.

## Linked Ticket

[CXE-14504](https://snowflakecomputing.atlassian.net/browse/CXE-14504) -- Eliminate Double-Rendering and Unify Step Template Rendering

Parent: [CXE-14437](https://snowflakecomputing.atlassian.net/browse/CXE-14437) -- Repo quality review/refinement

## Local Testing Performed

- All existing unit tests pass -- the thin `check_template_renderable` wrapper preserves the public API so no existing tests required modification (only `setUp` methods updated to use `create_jinja_env`).
- New `TestRenderStepTemplate` tests pass (5 cases covering the unified render function).
- Rendered output for blueprints remains byte-identical to pre-change output (no behavioral change to callers).

## How to Test

1. **Run the test suite:**
   ```bash
   cd scripts && python -m pytest test_render_journey.py -v
   ```
   Or with unittest:
   ```bash
   cd scripts && python -m unittest test_render_journey -v
   ```

2. **Verify new tests specifically:**
   ```bash
   cd scripts && python -m unittest test_render_journey.TestRenderStepTemplate -v
   ```

3. **Run the full rendering pipeline** on an existing blueprint and diff the output against the `main` branch -- output should be identical.

## Configuration / Migration Steps

None. This is a pure internal refactor with no changes to CLI arguments, configuration, or external interfaces.

## Breaking Changes

None. The rendered output for any given blueprint + answers combination remains byte-identical. The `check_template_renderable` public API is preserved via a thin wrapper. The deleted functions (`render_step_code`, `render_step_guidance`) were internal and not part of any external API.
