### PR TITLE
Update copyright headers to use generic year and expanded license reference

### DIFF
--- a/.cortex/commands/blueprints.md
+++ b/.cortex/commands/blueprints.md
@@ -1,5 +1,6 @@
-<!-- Copyright (c) 2026 Snowflake Inc. All rights reserved.
-     Licensed under the Snowflake Skills License. See LICENSE file. -->
+<!-- Copyright (c) YEAR Snowflake Inc. All rights reserved.
+     Licensed under the Snowflake Skills License. 
+     Refer to the LICENSE file in the root of this repository for full terms. -->
 
 # Blueprints Command
 

--- a/.cortex/commands/blueprints/answers/diff.md
+++ b/.cortex/commands/blueprints/answers/diff.md
@@ -1,5 +1,6 @@
-<!-- Copyright (c) 2026 Snowflake Inc. All rights reserved.
-     Licensed under the Snowflake Skills License. See LICENSE file. -->
+<!-- Copyright (c) YEAR Snowflake Inc. All rights reserved.
+     Licensed under the Snowflake Skills License. 
+     Refer to the LICENSE file in the root of this repository for full terms. -->
 
 # Blueprints Answers Diff
 

--- a/.cortex/commands/blueprints/answers/init.md
+++ b/.cortex/commands/blueprints/answers/init.md
@@ -1,5 +1,6 @@
-<!-- Copyright (c) 2026 Snowflake Inc. All rights reserved.
-     Licensed under the Snowflake Skills License. See LICENSE file. -->
+<!-- Copyright (c) YEAR Snowflake Inc. All rights reserved.
+     Licensed under the Snowflake Skills License. 
+     Refer to the LICENSE file in the root of this repository for full terms. -->
 
 # Blueprints Answers Init
 

--- a/.cortex/commands/blueprints/answers/validate.md
+++ b/.cortex/commands/blueprints/answers/validate.md
@@ -1,5 +1,6 @@
-<!-- Copyright (c) 2026 Snowflake Inc. All rights reserved.
-     Licensed under the Snowflake Skills License. See LICENSE file. -->
+<!-- Copyright (c) YEAR Snowflake Inc. All rights reserved.
+     Licensed under the Snowflake Skills License. 
+     Refer to the LICENSE file in the root of this repository for full terms. -->
 
 # Blueprints Answers Validate
 

--- a/.cortex/commands/blueprints/build.md
+++ b/.cortex/commands/blueprints/build.md
@@ -1,5 +1,6 @@
-<!-- Copyright (c) 2026 Snowflake Inc. All rights reserved.
-     Licensed under the Snowflake Skills License. See LICENSE file. -->
+<!-- Copyright (c) YEAR Snowflake Inc. All rights reserved.
+     Licensed under the Snowflake Skills License. 
+     Refer to the LICENSE file in the root of this repository for full terms. -->
 
 # Blueprints Build
 

--- a/.cortex/commands/blueprints/describe.md
+++ b/.cortex/commands/blueprints/describe.md
@@ -1,5 +1,6 @@
-<!-- Copyright (c) 2026 Snowflake Inc. All rights reserved.
-     Licensed under the Snowflake Skills License. See LICENSE file. -->
+<!-- Copyright (c) YEAR Snowflake Inc. All rights reserved.
+     Licensed under the Snowflake Skills License. 
+     Refer to the LICENSE file in the root of this repository for full terms. -->
 
 # Blueprints Describe
 

--- a/.cortex/commands/blueprints/list.md
+++ b/.cortex/commands/blueprints/list.md
@@ -1,5 +1,6 @@
-<!-- Copyright (c) 2026 Snowflake Inc. All rights reserved.
-     Licensed under the Snowflake Skills License. See LICENSE file. -->
+<!-- Copyright (c) YEAR Snowflake Inc. All rights reserved.
+     Licensed under the Snowflake Skills License. 
+     Refer to the LICENSE file in the root of this repository for full terms. -->
 
 # Blueprints List
 

--- a/.cortex/commands/blueprints/projects/create.md
+++ b/.cortex/commands/blueprints/projects/create.md
@@ -1,5 +1,6 @@
-<!-- Copyright (c) 2026 Snowflake Inc. All rights reserved.
-     Licensed under the Snowflake Skills License. See LICENSE file. -->
+<!-- Copyright (c) YEAR Snowflake Inc. All rights reserved.
+     Licensed under the Snowflake Skills License. 
+     Refer to the LICENSE file in the root of this repository for full terms. -->
 
 # Blueprints Projects Create
 

--- a/.cortex/commands/blueprints/projects/describe.md
+++ b/.cortex/commands/blueprints/projects/describe.md
@@ -1,5 +1,6 @@
-<!-- Copyright (c) 2026 Snowflake Inc. All rights reserved.
-     Licensed under the Snowflake Skills License. See LICENSE file. -->
+<!-- Copyright (c) YEAR Snowflake Inc. All rights reserved.
+     Licensed under the Snowflake Skills License. 
+     Refer to the LICENSE file in the root of this repository for full terms. -->
 
 # Blueprints Projects Describe
 

--- a/.cortex/commands/blueprints/projects/list.md
+++ b/.cortex/commands/blueprints/projects/list.md
@@ -1,5 +1,6 @@
-<!-- Copyright (c) 2026 Snowflake Inc. All rights reserved.
-     Licensed under the Snowflake Skills License. See LICENSE file. -->
+<!-- Copyright (c) YEAR Snowflake Inc. All rights reserved.
+     Licensed under the Snowflake Skills License. 
+     Refer to the LICENSE file in the root of this repository for full terms. -->
 
 # Blueprints Projects List
 

--- a/.cortex/commands/blueprints/render.md
+++ b/.cortex/commands/blueprints/render.md
@@ -1,5 +1,6 @@
-<!-- Copyright (c) 2026 Snowflake Inc. All rights reserved.
-     Licensed under the Snowflake Skills License. See LICENSE file. -->
+<!-- Copyright (c) YEAR Snowflake Inc. All rights reserved.
+     Licensed under the Snowflake Skills License. 
+     Refer to the LICENSE file in the root of this repository for full terms. -->
 
 # Blueprints Render
 

--- a/.cortex/commands/blueprints/validate.md
+++ b/.cortex/commands/blueprints/validate.md
@@ -1,5 +1,6 @@
-<!-- Copyright (c) 2026 Snowflake Inc. All rights reserved.
-     Licensed under the Snowflake Skills License. See LICENSE file. -->
+<!-- Copyright (c) YEAR Snowflake Inc. All rights reserved.
+     Licensed under the Snowflake Skills License. 
+     Refer to the LICENSE file in the root of this repository for full terms. -->
 
 # Blueprints Validate
 

--- a/.cortex/skills/blueprint-builder/SKILL.md
+++ b/.cortex/skills/blueprint-builder/SKILL.md
@@ -1,5 +1,6 @@
-<!-- Copyright (c) 2026 Snowflake Inc. All rights reserved.
-     Licensed under the Snowflake Skills License. See LICENSE file. -->
+<!-- Copyright (c) YEAR Snowflake Inc. All rights reserved.
+     Licensed under the Snowflake Skills License. 
+     Refer to the LICENSE file in the root of this repository for full terms. -->
 
 ---
 name: blueprint-builder

--- a/.cortex/skills/snowflake-best-practices/SKILL.md
+++ b/.cortex/skills/snowflake-best-practices/SKILL.md
@@ -1,5 +1,6 @@
-<!-- Copyright (c) 2026 Snowflake Inc. All rights reserved.
-     Licensed under the Snowflake Skills License. See LICENSE file. -->
+<!-- Copyright (c) YEAR Snowflake Inc. All rights reserved.
+     Licensed under the Snowflake Skills License. 
+     Refer to the LICENSE file in the root of this repository for full terms. -->
 
 ---
 name: snowflake-best-practices

--- a/scripts/render_journey.py
+++ b/scripts/render_journey.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 
-# Copyright (c) 2026 Snowflake Inc. All rights reserved.
-# Licensed under the Snowflake Skills License. See LICENSE file.
+# Copyright (c) YEAR Snowflake Inc. All rights reserved.
+# Licensed under the Snowflake Skills License.
+# Refer to the LICENSE file in the root of this repository for full terms.
 
 """
 render_journey.py

--- a/scripts/test_render_journey.py
+++ b/scripts/test_render_journey.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 
-# Copyright (c) 2026 Snowflake Inc. All rights reserved.
-# Licensed under the Snowflake Skills License. See LICENSE file.
+# Copyright (c) YEAR Snowflake Inc. All rights reserved.
+# Licensed under the Snowflake Skills License.
+# Refer to the LICENSE file in the root of this repository for full terms.
 
 """
 Unit tests for render_journey.py


### PR DESCRIPTION
## Summary
- Standardize copyright headers across all 16 source and command files to use a `YEAR` placeholder instead of a hardcoded year
- Expand the license reference line from `See LICENSE file.` to `Refer to the LICENSE file in the root of this repository for full terms.`

## Test plan
- [ ] Verify copyright headers are consistent across all modified files
- [ ] Confirm no functional code changes were introduced
- [ ] Validate that `render_journey.py` and `test_render_journey.py` still run correctly

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)