### PR TITLE
CXE-14541: Fix broken table of contents links in rendered documentation

### DIFF
--- a/scripts/render_journey.py
+++ b/scripts/render_journey.py
@@ -568,13 +568,16 @@ def generate_table_of_contents(tasks, rendered_steps, depth=2, blueprint_dir=Non
     Generate a hierarchical Table of Contents for rendered blueprint documentation.
     
     Creates a markdown-formatted TOC from the task→step hierarchy with proper
-    anchor links. Only includes steps that were actually rendered (not skipped).
+    anchor links. Includes both rendered and skipped steps so that TOC numbering
+    stays consistent with the document body (where skipped steps still appear
+    with a "SKIPPED" note). Steps without template files are excluded entirely.
     
     Args:
         tasks: List of task metadata dictionaries from load_task_metadata().
                Each task should have 'slug', 'title', and 'steps' keys.
-        rendered_steps: Set or list of step slugs that were successfully rendered.
-                       Steps not in this collection are excluded from the TOC.
+        rendered_steps: Set or list of step slugs that have template files.
+                       Steps not in this collection are excluded from the TOC
+                       (these are steps with no template that produce no body output).
         depth: Controls nesting levels in TOC (default: 2)
                - depth=1: Only tasks (no steps)
                - depth=2: Tasks and steps (default)
@@ -628,16 +631,17 @@ def generate_table_of_contents(tasks, rendered_steps, depth=2, blueprint_dir=Non
         
         # Add step entries if depth >= 2
         if depth >= 2:
-            step_num_in_task = 0
-            for step in task_steps:
+            for step_index, step in enumerate(task_steps):
                 slug = get_step_slug(step)
                 
-                # Skip steps that weren't rendered
+                # Skip steps that don't have templates (these produce
+                # no output in the document body at all)
                 if slug not in rendered_set:
                     continue
                 
-                step_num_in_task += 1
-                step_label = f"{task_num}.{step_num_in_task}"
+                # Use position-based numbering so TOC labels match
+                # the body headings (which use step_mapping step_index)
+                step_label = f"{task_num}.{step_index + 1}"
                 
                 # Use resolve_step_title for consistent fallback with body headings
                 if blueprint_dir is not None:
@@ -1078,9 +1082,11 @@ def render_blueprint_guidance(blueprint_dir, answers, base_dir, blueprint_meta, 
     step_mapping = task_context.get("step_mapping", {}) if task_context else {}
     tasks = task_context.get("tasks", []) if task_context else []
 
-    # PHASE 1: Pre-scan to determine which steps can be rendered
-    # This is needed to generate an accurate TOC that respects skipped steps
-    renderable_steps = set()
+    # PHASE 1: Pre-scan to determine which steps have templates
+    # The TOC includes ALL steps that have a template file (both renderable
+    # and skipped), so that numbering stays consistent with the document body
+    # where skipped steps still appear with a "SKIPPED" note.
+    toc_steps = set()
     for step_id in step_order:
         step_path = blueprint_dir / step_id
         if not step_path.exists():
@@ -1090,12 +1096,7 @@ def render_blueprint_guidance(blueprint_dir, answers, base_dir, blueprint_meta, 
         if not dynamic_file.exists():
             continue
         
-        # Check if this step can be rendered
-        can_render, _, _ = check_template_renderable(
-            dynamic_file, answers, jinja_env, base_dir
-        )
-        if can_render:
-            renderable_steps.add(step_id)
+        toc_steps.add(step_id)
 
     # PHASE 2: Build header with task-aware TOC
     rendered_sections = []
@@ -1125,9 +1126,9 @@ def render_blueprint_guidance(blueprint_dir, answers, base_dir, blueprint_meta, 
 
     rendered_sections.append("\n".join(header))
 
-    # Generate and add hierarchical table of contents (only includes rendered steps)
+    # Generate and add hierarchical table of contents (includes all steps with templates)
     if tasks:
-        toc = generate_table_of_contents(tasks, renderable_steps, depth=toc_depth, blueprint_dir=blueprint_dir, task_context=task_context)
+        toc = generate_table_of_contents(tasks, toc_steps, depth=toc_depth, blueprint_dir=blueprint_dir, task_context=task_context)
         if toc:
             rendered_sections.append(toc)
 

--- a/scripts/test_render_journey.py
+++ b/scripts/test_render_journey.py
@@ -991,7 +991,7 @@ class TestGenerateTableOfContents(TestCase):
         self.assertIn("  - [Step 1.2: Set Up Roles](#step-12-set-up-roles)", toc)
 
     def test_generate_toc_respects_skipped_steps(self):
-        """Skipped steps should not appear in TOC."""
+        """Steps without templates should not appear in TOC but numbering should be positional."""
         from render_journey import generate_table_of_contents
 
         tasks = [
@@ -1000,19 +1000,47 @@ class TestGenerateTableOfContents(TestCase):
                 "title": "Platform Foundation",
                 "steps": [
                     {"slug": "step-1", "title": "Configure Account"},
-                    {"slug": "step-2", "title": "Skipped Step"},
+                    {"slug": "step-2", "title": "No Template Step"},
                     {"slug": "step-3", "title": "Set Up Roles"},
                 ],
             },
         ]
-        # Only step-1 and step-3 were rendered
+        # step-1 and step-3 have templates; step-2 does not
         rendered_steps = {"step-1", "step-3"}
 
         toc = generate_table_of_contents(tasks, rendered_steps)
 
         self.assertIn("Step 1.1: Configure Account", toc)
-        self.assertIn("Step 1.2: Set Up Roles", toc)  # Note: numbered 1.2, not 1.3
-        self.assertNotIn("Skipped Step", toc)
+        self.assertIn("Step 1.3: Set Up Roles", toc)  # Positional numbering preserved
+        self.assertNotIn("No Template Step", toc)
+
+    def test_generate_toc_includes_skipped_steps_with_templates(self):
+        """Steps with templates but missing vars (skipped) should appear in the TOC.
+
+        The document body renders a 'SKIPPED' note for these steps, so the TOC
+        must include them to keep numbering aligned with the body.
+        """
+        from render_journey import generate_table_of_contents
+
+        tasks = [
+            {
+                "slug": "task-1",
+                "title": "Platform Foundation",
+                "steps": [
+                    {"slug": "step-1", "title": "Configure Account"},
+                    {"slug": "step-2", "title": "Set Up Network"},
+                    {"slug": "step-3", "title": "Set Up Roles"},
+                ],
+            },
+        ]
+        # All three steps have templates (renderable or skipped)
+        rendered_steps = {"step-1", "step-2", "step-3"}
+
+        toc = generate_table_of_contents(tasks, rendered_steps)
+
+        self.assertIn("Step 1.1: Configure Account", toc)
+        self.assertIn("Step 1.2: Set Up Network", toc)
+        self.assertIn("Step 1.3: Set Up Roles", toc)
 
     def test_generate_toc_skips_empty_tasks(self):
         """Tasks with no rendered steps should be skipped entirely."""
@@ -2498,6 +2526,63 @@ class TestTocToHeadingAnchorConsistency(BlueprintTestCase):
         # Verify the rendered body uses the jinja title, not the slug
         self.assertIn("Set Up VPC Networking", rendered)
         self.assertNotIn("setup-networking", rendered.split("Set Up VPC Networking")[0].split("Step")[-1])
+
+    def test_toc_includes_skipped_steps_and_numbering_matches_body(self):
+        """TOC must include skipped steps so numbering stays aligned with the body.
+
+        When step 1 is skipped (missing vars) and step 2 renders successfully,
+        the TOC should list both steps with correct positional numbering (1.1, 1.2)
+        and the anchors must match the body headings.
+        """
+        from render_journey import (
+            render_blueprint_guidance, generate_anchor,
+        )
+
+        steps = [
+            {"slug": "step-1", "title": "Configure Network"},
+            {"slug": "step-2", "title": "Set Up Roles"},
+        ]
+        meta, task_context = self._make_meta_and_context("Platform Setup", steps)
+
+        # step-1 requires a variable (will be skipped)
+        step_dir_1 = self.base_dir / "step-1"
+        step_dir_1.mkdir(parents=True, exist_ok=True)
+        (step_dir_1 / "dynamic.md.jinja").write_text(
+            "# Configure Network\n\nNetwork: {{ network_id }}"
+        )
+
+        # step-2 has no variables (will render)
+        step_dir_2 = self.base_dir / "step-2"
+        step_dir_2.mkdir(parents=True, exist_ok=True)
+        (step_dir_2 / "dynamic.md.jinja").write_text(
+            "# Set Up Roles\n\nRoles configured."
+        )
+
+        # Render with no answers — step-1 skipped, step-2 renders
+        rendered, rendered_count, skipped_count = render_blueprint_guidance(
+            self.base_dir, {}, self.base_dir, meta,
+            date_display="2026-01-01 00:00:00", task_context=task_context,
+        )
+
+        self.assertEqual(rendered_count, 1)
+        self.assertEqual(skipped_count, 1)
+
+        # The TOC should include BOTH steps
+        self.assertIn("Step 1.1: Configure Network", rendered)
+        self.assertIn("Step 1.2: Set Up Roles", rendered)
+
+        # The body should have the skipped step heading
+        self.assertIn("SKIPPED", rendered)
+
+        # TOC anchors for both steps should match body headings
+        import re
+        toc_anchors = re.findall(r'\(#([^)]+)\)', rendered)
+        step_anchors = [a for a in toc_anchors if a.startswith("step-")]
+        self.assertEqual(len(step_anchors), 2)
+
+        # Verify anchor values match what the body headings produce
+        self.assertEqual(step_anchors[0], generate_anchor("Step 1.1: Configure Network"))
+        self.assertEqual(step_anchors[1], generate_anchor("Step 1.2: Set Up Roles"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Fix Broken Table of Contents Links in Rendered Documentation

## Description & Motivation

In the documentation output by `scripts/render_journey.py`, some Table of Contents (TOC) links don't redirect to the relevant section. This is because the TOC and the document body were using **different sources** for step titles, producing mismatched anchor IDs.

Three root causes were identified:

1. **Title source mismatch** -- The TOC (`generate_table_of_contents()`) reads titles from `meta.yaml`, but the document body (`render_blueprint_guidance()` / `render_blueprint_code()`) used `get_step_title()` which reads from `dynamic.md.jinja`. When a jinja template has no `# ` title line, the body falls back to the raw step slug, producing a different anchor than the TOC.
2. **Divergent titles** -- Some steps have different human-readable titles in `meta.yaml` vs their `dynamic.md.jinja` template (e.g., "Create Organization Account Administrators" vs "Create Account Administrators"), causing anchor mismatches.
3. **Special character handling** -- Characters like `&`, `,`, `()` in titles are stripped by `generate_anchor()`. This is fine as long as both TOC and body use the same title string, but the bugs above meant they often didn't.

**Fix:** Introduced a `resolve_step_title()` function that establishes `meta.yaml` as the single source of truth for step titles (matching what the TOC already uses), with fallback to jinja template title, then to the slug. All four call sites in `render_blueprint_guidance()` and `render_blueprint_code()` now use this function, ensuring TOC and body anchors always match.

## Ticket

[CXE-14541](https://snowflakecomputing.atlassian.net/browse/CXE-14541) -- "Some table of contents links don't work"

- Parent: [CXE-14390](https://snowflakecomputing.atlassian.net/browse/CXE-14390) -- M2: Checklist to make Blueprints repo public
- Epic: [CXE-14156](https://snowflakecomputing.atlassian.net/browse/CXE-14156) -- M2: Select customers and SI partners using Blueprints directly

## Changes

### `scripts/render_journey.py`
- Added `resolve_step_title(step_id, step_path, task_context)` -- canonical title resolution with priority: meta.yaml title > jinja `# ` title > slug.
- Updated all four step-title resolution sites in `render_blueprint_code()` (skip header + normal header) and `render_blueprint_guidance()` (skip header + normal header) to use `resolve_step_title()` instead of the previous inline `get_step_title()` / slug fallback logic.

### `scripts/test_render_journey.py`
- Added `TestResolveStepTitle` (7 tests) -- unit tests for the new `resolve_step_title()` function covering: meta.yaml preferred over jinja, fallback to jinja when meta is empty, fallback to slug when neither has a title, no task_context scenarios, and step-not-found-in-context fallback.
- Added `TestTocToHeadingAnchorConsistency` (5 tests) -- integration tests verifying that TOC anchors match body heading anchors for: divergent jinja/meta titles (Bug 2), missing jinja titles (Bug 1), `&` in titles (Bug 3), commas and special characters, and task-level anchors.

## Local Testing

- All existing tests pass (`python -m pytest scripts/test_render_journey.py`).
- 12 new tests pass, covering all three bugs and edge cases.
- Manual verification: rendered output for steps with known mismatches (e.g., `configure-scim-integration`, `create-organization-account-administrators`, `define-domains-environments-and-object-naming-conventions`) now produces matching TOC-to-heading anchors.

## How to Test / Review

1. Run the full test suite:
   ```bash
   python -m pytest scripts/test_render_journey.py -v
   ```
2. Focus on the new tests:
   ```bash
   python -m pytest scripts/test_render_journey.py -v -k "TestResolveStepTitle or TestTocToHeadingAnchorConsistency"
   ```
3. Optionally render a blueprint with known mismatches (e.g., `platform-foundation-setup`) and verify that all TOC links navigate to the correct sections in the output markdown.

## Config / Migration Steps

None. This is a pure code change with no configuration, migration, or environment changes.

## Breaking Changes

None. The external behavior is corrected (TOC links now work), but no APIs, CLI interfaces, or configuration formats are changed.
