### PR TITLE
RBAC Hardening v2: expand Assess phase with 4 new diagnostic checks

### DIFF
--- a/blueprints/rbac-hardening/audit-privilege-grants/code.sql.jinja
+++ b/blueprints/rbac-hardening/audit-privilege-grants/code.sql.jinja
@@ -137,6 +137,31 @@ WHERE name = 'ACCOUNTADMIN'
   AND deleted_on IS NULL;
 
 -- ============================================================================
+-- STEP 6: RECENT GRANT VELOCITY
+-- ============================================================================
+-- Find grants created in the last 30 days, grouped by day.
+-- High-churn periods signal ad-hoc access patterns or bulk provisioning events
+-- that may have bypassed normal governance controls.
+
+SELECT
+  DATE_TRUNC('day', created_on) AS grant_date,
+  COUNT(*) AS grants_created,
+  COUNT(DISTINCT grantee_name) AS distinct_grantees
+FROM SNOWFLAKE.ACCOUNT_USAGE.GRANTS_TO_ROLES
+WHERE created_on > DATEADD('day', -30, CURRENT_TIMESTAMP())
+  AND deleted_on IS NULL
+  AND granted_on != 'ROLE'  -- Object grants only, not role-to-role
+{%- if rbac_audit_scope == 'Specific Data Products' %}
+  AND (
+{%- for prefix in rbac_target_prefixes %}
+    grantee_name LIKE '{{ prefix | upper }}%'{% if not loop.last %} OR{% endif %}
+{%- endfor %}
+  )
+{%- endif %}
+GROUP BY grant_date
+ORDER BY grant_date DESC;
+
+-- ============================================================================
 -- VERIFICATION
 -- ============================================================================
 
@@ -155,6 +180,7 @@ Queries generated:
 3. ACCOUNTADMIN holders (should be 2-3 break-glass users)
 4. Roles with powerful account-level privileges
 5. Summary statistics
+6. Recent grant velocity (last 30 days)
 
 Audit Scope: {{ rbac_audit_scope }}
 

--- a/blueprints/rbac-hardening/audit-privilege-grants/dynamic.md.jinja
+++ b/blueprints/rbac-hardening/audit-privilege-grants/dynamic.md.jinja
@@ -20,6 +20,7 @@
 | 3 | ACCOUNTADMIN Holders | Users with the most powerful role | Critical |
 | 4 | Powerful Privileges | Non-system roles with account-level privileges | Medium |
 | 5 | Summary Statistics | Aggregate grant health metrics | Info |
+| 6 | Recent Grant Velocity | High-churn grant activity in last 30 days | Medium |
 
 ## Risk Assessment Guide
 
@@ -33,6 +34,14 @@ Each grant is effectively given to every user. Review each and either:
 
 ### ACCOUNTADMIN Holders (Critical)
 Best practice is 2-3 break-glass users maximum. Compare results against `rbac_accountadmin_users` list in Task 2 (Enforce Admin Separation).
+
+### Recent Grant Velocity (Medium)
+Spikes in daily grant activity indicate bulk access events or ad-hoc provisioning outside normal governance. Look for:
+- Days with significantly higher grant counts than the baseline
+- Grants clustered around weekends or off-hours
+- A high number of distinct grantees on a single day
+
+Investigate the specific grants from high-churn days to confirm they were intentional and authorized.
 
 ## Next Steps
 

--- a/blueprints/rbac-hardening/audit-role-hierarchy/code.sql.jinja
+++ b/blueprints/rbac-hardening/audit-role-hierarchy/code.sql.jinja
@@ -145,6 +145,62 @@ SELECT
   ) AS orphaned_roles;
 
 -- ============================================================================
+-- STEP 5: OBJECT OWNERSHIP CONCENTRATION
+-- ============================================================================
+-- Find roles that own a disproportionate number of objects.
+-- Concentrated ownership creates single points of failure: if the role is
+-- dropped or misconfigured, all owned objects become inaccessible.
+
+SELECT
+  grantee_name AS role_name,
+  granted_on AS object_type,
+  COUNT(*) AS owned_objects
+FROM SNOWFLAKE.ACCOUNT_USAGE.GRANTS_TO_ROLES
+WHERE privilege = 'OWNERSHIP'
+  AND deleted_on IS NULL
+{%- if rbac_audit_scope == 'Specific Data Products' %}
+  AND (
+{%- for prefix in rbac_target_prefixes %}
+    grantee_name LIKE '{{ prefix | upper }}%'{% if not loop.last %} OR{% endif %}
+{%- endfor %}
+  )
+{%- endif %}
+GROUP BY grantee_name, granted_on
+HAVING COUNT(*) > 10
+ORDER BY owned_objects DESC;
+
+-- ============================================================================
+-- STEP 6: OWNERSHIP WITHOUT HIERARCHY PARENT
+-- ============================================================================
+-- Find roles that own objects but are not granted to any parent role.
+-- These roles sit outside the hierarchy: ownership without accountability.
+-- If dropped, the owned objects lose their owner and become inaccessible.
+
+SELECT
+  gr.grantee_name AS role_name,
+  COUNT(*) AS owned_objects
+FROM SNOWFLAKE.ACCOUNT_USAGE.GRANTS_TO_ROLES gr
+WHERE gr.privilege = 'OWNERSHIP'
+  AND gr.deleted_on IS NULL
+  AND gr.grantee_name NOT IN ('ACCOUNTADMIN', 'SECURITYADMIN', 'SYSADMIN', 'USERADMIN', 'PUBLIC', 'ORGADMIN')
+  AND gr.grantee_name NOT IN (
+    SELECT DISTINCT name
+    FROM SNOWFLAKE.ACCOUNT_USAGE.GRANTS_TO_ROLES
+    WHERE granted_on = 'ROLE'
+      AND privilege = 'USAGE'
+      AND deleted_on IS NULL
+  )
+{%- if rbac_audit_scope == 'Specific Data Products' %}
+  AND (
+{%- for prefix in rbac_target_prefixes %}
+    gr.grantee_name LIKE '{{ prefix | upper }}%'{% if not loop.last %} OR{% endif %}
+{%- endfor %}
+  )
+{%- endif %}
+GROUP BY gr.grantee_name
+ORDER BY owned_objects DESC;
+
+-- ============================================================================
 -- VERIFICATION
 -- ============================================================================
 
@@ -162,6 +218,8 @@ Queries generated:
 2. Orphaned roles (no parent grant)
 3. Excessive hierarchy depth (>5 levels)
 4. Role grant summary statistics
+5. Object ownership concentration (>10 objects per role)
+6. Ownership without hierarchy parent (structural gap)
 
 Audit Scope: {{ rbac_audit_scope }}
 {%- if rbac_audit_scope == 'Specific Data Products' %}

--- a/blueprints/rbac-hardening/audit-role-hierarchy/dynamic.md.jinja
+++ b/blueprints/rbac-hardening/audit-role-hierarchy/dynamic.md.jinja
@@ -19,6 +19,8 @@
 | 2 | Orphaned Roles | Roles not granted to any parent (unreachable) |
 | 3 | Excessive Depth | Roles with hierarchy depth > 5 levels |
 | 4 | Role Grant Summary | Aggregate health statistics |
+| 5 | Ownership Concentration | Roles owning >10 objects (single point of failure risk) |
+| 6 | Ownership Without Parent | Roles that own objects but have no parent in the hierarchy |
 
 {%- if rbac_audit_scope == 'Specific Data Products' %}
 
@@ -48,6 +50,17 @@ Roles with no parent grant are unreachable from the standard hierarchy. Common c
 
 ### Excessive Depth
 Hierarchies deeper than 5 levels make it difficult to reason about effective privileges. The standard Data Product Setup hierarchy is 4 levels deep: READ → WRITE → CREATE → ADMIN → SYSADMIN.
+
+### Ownership Concentration
+Roles owning more than 10 objects are a single point of failure. If the role is accidentally dropped or misconfigured, all owned objects become inaccessible. Consider distributing ownership across schema-level or database-level roles to reduce blast radius.
+
+### Ownership Without Hierarchy Parent
+These roles own objects but sit outside the standard hierarchy — they have no parent role and are not reachable from SYSADMIN. This is a structural gap: ownership exists without accountability or a clear governance path. Common causes:
+- Roles created manually for one-off migrations or projects
+- Leftover roles from decommissioned data products
+- Service account roles granted object ownership directly
+
+Remediation: wire each role into the hierarchy (grant it to an appropriate parent), or transfer OWNERSHIP to a correctly-placed role and drop it.
 
 ## Next Steps
 

--- a/blueprints/rbac-hardening/audit-stale-access/code.sql.jinja
+++ b/blueprints/rbac-hardening/audit-stale-access/code.sql.jinja
@@ -138,6 +138,32 @@ GROUP BY login_status
 ORDER BY user_count DESC;
 
 -- ============================================================================
+-- STEP 5: ROLE ACCUMULATION PER USER
+-- ============================================================================
+-- Find users who have been granted more than 10 roles.
+-- Over-provisioned users accumulate roles over time through project access,
+-- team changes, and one-off requests that never get cleaned up.
+
+SELECT
+  grantee_name AS user_name,
+  COUNT(*) AS role_count,
+  LISTAGG(name, ', ') WITHIN GROUP (ORDER BY name) AS granted_roles
+FROM SNOWFLAKE.ACCOUNT_USAGE.GRANTS_TO_USERS
+WHERE granted_on = 'ROLE'
+  AND privilege = 'USAGE'
+  AND deleted_on IS NULL
+{%- if rbac_audit_scope == 'Specific Data Products' %}
+  AND (
+{%- for prefix in rbac_target_prefixes %}
+    name LIKE '{{ prefix | upper }}%'{% if not loop.last %} OR{% endif %}
+{%- endfor %}
+  )
+{%- endif %}
+GROUP BY grantee_name
+HAVING COUNT(*) > 10
+ORDER BY role_count DESC;
+
+-- ============================================================================
 -- VERIFICATION
 -- ============================================================================
 
@@ -158,6 +184,7 @@ Queries generated:
 2. Users who have never logged in but have role grants
 3. Unused roles (no direct user assignments)
 4. User access health summary by login activity bucket
+5. Role accumulation per user (>10 roles)
 
 Audit Scope: {{ rbac_audit_scope }}
 

--- a/blueprints/rbac-hardening/audit-stale-access/dynamic.md.jinja
+++ b/blueprints/rbac-hardening/audit-stale-access/dynamic.md.jinja
@@ -19,6 +19,7 @@
 | 2 | Never Logged In | Users with grants who have never authenticated | High |
 | 3 | Unused Roles | Roles with no user assignments | Medium |
 | 4 | Health Summary | User activity buckets (Active/Stale/Dormant/Never) | Info |
+| 5 | Role Accumulation | Users with >10 active roles (over-provisioned) | Medium |
 
 ## Activity Thresholds
 
@@ -40,6 +41,12 @@
 1. Verify the role is not part of an active hierarchy (check Step 1.1 results)
 2. Confirm no automated processes depend on the role
 3. Drop the role: `DROP ROLE <role>;`
+
+### For Over-Provisioned Users (>10 Roles)
+Role accumulation happens gradually — project access, team changes, and one-off grants that never get revoked. For each user in the results:
+1. Review the full role list and identify roles that are no longer needed
+2. Revoke excess roles: `REVOKE ROLE <role> FROM USER <user>;`
+3. For users with functional roles from multiple data products, confirm each product access is still required
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary

Adds 4 new diagnostic SQL queries across the three Assess-phase steps of the `rbac-hardening` blueprint, expanding coverage of structural and behavioral RBAC risks:

- **audit-privilege-grants** — Step 6: Recent Grant Velocity (last 30 days). Surfaces high-churn grant periods that may indicate bulk provisioning or governance bypass.
- **audit-role-hierarchy** — Step 5: Object Ownership Concentration (roles owning >10 objects, single point of failure). Step 6: Ownership Without Hierarchy Parent (roles that own objects but sit outside the standard hierarchy).
- **audit-stale-access** — Step 5: Role Accumulation Per User (users with >10 active roles, over-provisioned access).

Each new query includes a matching `dynamic.md.jinja` guidance section explaining the risk, what to look for, and remediation steps. All queries respect the `rbac_audit_scope` conditional filter for "Specific Data Products" mode.

## Test plan

- [ ] Render the `rbac-hardening` blueprint end-to-end with `rbac_audit_scope = 'All Roles'` and verify all new steps appear in the generated SQL and guidance docs
- [ ] Render with `rbac_audit_scope = 'Specific Data Products'` and verify the `rbac_target_prefixes` filter is applied correctly in all new queries
- [ ] Confirm verification footers in each `code.sql.jinja` file list all steps accurately (no numbering gaps)
- [ ] Review generated guidance markdown for correct table rows and explanation sections

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)