### PR TITLE
CXE-15276: Update blueprint-builder SKILL.md with three-stage option resolution logic

### DIFF
--- a/.cortex/skills/blueprint-builder/SKILL.md
+++ b/.cortex/skills/blueprint-builder/SKILL.md
@@ -636,7 +636,7 @@ Before presenting a step's details, check whether this step is the **first step 
    > For every single-select or multi-select question, options are resolved in this priority order:
    > - **Stage 1 (Dynamic, primary):** If the question has a `dynamic_options_source` field, look up the current in-memory answer for the `answer_title` referenced by that field. If the answer is non-empty (the source question has been answered and contains list values), use those list values as the options. Proceed to render normally.
    > - **Stage 2 (Static fallback):** If Stage 1 yields no options (either `dynamic_options_source` is absent, or the referenced source answer is empty/unanswered), check whether the question has a static `options` list. If present, use it. Proceed to render normally.
-   > - **Stage 3 (Block):** Only if neither Stage 1 nor Stage 2 yields options, block the question. Display a notice that varies by sub-case: if the source question has not been answered yet, tell the user to complete it first; if the source question was answered but produced no usable values (empty or non-list result), tell the user that no options are available from that answer.
+   > - **Stage 3 (Block):** Only if neither Stage 1 nor Stage 2 yields options, block the question. Display a notice that varies by sub-case: if the source question was answered but produced no usable values (empty or non-list result), tell the user that no options are available from that answer; if the source question has not been answered yet, tell the user to complete it first; if there is no `dynamic_options_source` at all (and no static `options` list), tell the user that no options are available and the question definition should be checked.
    >
    > A question with both `dynamic_options_source` and a static `options` list is valid: Stage 1 takes priority when the source is answered; Stage 2 provides a graceful fallback when it is not. Never treat `dynamic_options_source` and `options` as mutually exclusive.
 
@@ -669,9 +669,12 @@ Before presenting a step's details, check whether this step is the **first step 
        → if source_was_answered:
            Display: "⚠️ This question has no available options. '[source_title]'
                      was answered but produced no selectable values."
-         else:
+         elif source_title is present:
            Display: "⚠️ This question cannot be answered yet. Please complete
                      '[source_title]' first, then return to this question."
+         else:
+           Display: "⚠️ This question has no available options and no dynamic
+                     source is configured. Check the question definition."
        → Skip to next question
      else:
        → Render question normally using resolved_options
@@ -710,6 +713,8 @@ Before presenting a step's details, check whether this step is the **first step 
     ⚠️ This question cannot be answered yet. Please complete '[source_title]' first, then return to this question.
     [For single-select / multi-select questions — Stage 3 blocked (source answered, no usable values):]
     ⚠️ This question has no available options. '[source_title]' was answered but produced no selectable values.
+    [For single-select / multi-select questions — Stage 3 blocked (no dynamic source configured):]
+    ⚠️ This question has no available options and no dynamic source is configured. Check the question definition.
     
     ---
     
@@ -732,6 +737,8 @@ Before presenting a step's details, check whether this step is the **first step 
     ⚠️ This question cannot be answered yet. Please complete '[source_title]' first, then return to this question.
     [For single-select / multi-select questions — Stage 3 blocked (source answered, no usable values):]
     ⚠️ This question has no available options. '[source_title]' was answered but produced no selectable values.
+    [For single-select / multi-select questions — Stage 3 blocked (no dynamic source configured):]
+    ⚠️ This question has no available options and no dynamic source is configured. Check the question definition.
    
    ---
    

--- a/.cortex/skills/blueprint-builder/SKILL.md
+++ b/.cortex/skills/blueprint-builder/SKILL.md
@@ -636,7 +636,7 @@ Before presenting a step's details, check whether this step is the **first step 
    > For every single-select or multi-select question, options are resolved in this priority order:
    > - **Stage 1 (Dynamic, primary):** If the question has a `dynamic_options_source` field, look up the current in-memory answer for the `answer_title` referenced by that field. If the answer is non-empty (the source question has been answered and contains list values), use those list values as the options. Proceed to render normally.
    > - **Stage 2 (Static fallback):** If Stage 1 yields no options (either `dynamic_options_source` is absent, or the referenced source answer is empty/unanswered), check whether the question has a static `options` list. If present, use it. Proceed to render normally.
-   > - **Stage 3 (Block):** Only if neither Stage 1 nor Stage 2 yields options, block the question. Display a notice naming the source question (the `answer_title` from `dynamic_options_source`) that must be completed first.
+   > - **Stage 3 (Block):** Only if neither Stage 1 nor Stage 2 yields options, block the question. Display a notice that varies by sub-case: if the source question has not been answered yet, tell the user to complete it first; if the source question was answered but produced no usable values (empty or non-list result), tell the user that no options are available from that answer.
    >
    > A question with both `dynamic_options_source` and a static `options` list is valid: Stage 1 takes priority when the source is answered; Stage 2 provides a graceful fallback when it is not. Never treat `dynamic_options_source` and `options` as mutually exclusive.
 
@@ -647,12 +647,16 @@ Before presenting a step's details, check whether this step is the **first step 
 
      resolved_options = []
      source_title = question.dynamic_options_source  # may be null/absent
+     source_was_answered = false
 
      # Stage 1 — Dynamic (primary)
      if source_title is present:
-       source_answer = in_memory_answers.get(source_title)
-       if source_answer is non-empty list:
-         resolved_options = source_answer
+       if source_title in in_memory_answers:           # key exists → source was answered
+         source_answer = in_memory_answers[source_title]
+         if source_answer is non-empty list:
+           resolved_options = source_answer
+         else:
+           source_was_answered = true                  # answered but produced no usable options
 
      # Stage 2 — Static fallback
      if resolved_options is empty:
@@ -662,9 +666,12 @@ Before presenting a step's details, check whether this step is the **first step 
      # Stage 3 — Block
      if resolved_options is empty:
        → Do NOT render the question for input
-       → Display blocking notice:
-         "⚠️ This question cannot be answered yet. Please complete
-          '[source_title]' first, then return to this question."
+       → if source_was_answered:
+           Display: "⚠️ This question has no available options. '[source_title]'
+                     was answered but produced no selectable values."
+         else:
+           Display: "⚠️ This question cannot be answered yet. Please complete
+                     '[source_title]' first, then return to this question."
        → Skip to next question
      else:
        → Render question normally using resolved_options
@@ -699,8 +706,10 @@ Before presenting a step's details, check whether this step is the **first step 
       1. [option 1 text]
       2. [option 2 text]
       ...
-    [For single-select / multi-select questions — Stage 3 blocked (no dynamic or static options available):]
+    [For single-select / multi-select questions — Stage 3 blocked (source unanswered):]
     ⚠️ This question cannot be answered yet. Please complete '[source_title]' first, then return to this question.
+    [For single-select / multi-select questions — Stage 3 blocked (source answered, no usable values):]
+    ⚠️ This question has no available options. '[source_title]' was answered but produced no selectable values.
     
     ---
     
@@ -719,8 +728,10 @@ Before presenting a step's details, check whether this step is the **first step 
       1. [option 1 text]
       2. [option 2 text]
       ...
-    [For single-select / multi-select questions — Stage 3 blocked (no dynamic or static options available):]
+    [For single-select / multi-select questions — Stage 3 blocked (source unanswered):]
     ⚠️ This question cannot be answered yet. Please complete '[source_title]' first, then return to this question.
+    [For single-select / multi-select questions — Stage 3 blocked (source answered, no usable values):]
+    ⚠️ This question has no available options. '[source_title]' was answered but produced no selectable values.
    
    ---
    

--- a/.cortex/skills/blueprint-builder/SKILL.md
+++ b/.cortex/skills/blueprint-builder/SKILL.md
@@ -634,11 +634,12 @@ Before presenting a step's details, check whether this step is the **first step 
 
    > **Maintainer note — Three-Stage Option Resolution:**
    > For every single-select or multi-select question, options are resolved in this priority order:
-   > - **Stage 1 (Dynamic, primary):** If the question has a `dynamic_options_source` field, look up the current in-memory answer for the `answer_title` referenced by that field. If the answer is non-empty (the source question has been answered and contains list values), use those list values as the options. Proceed to render normally.
-   > - **Stage 2 (Static fallback):** If Stage 1 yields no options (either `dynamic_options_source` is absent, or the referenced source answer is empty/unanswered), check whether the question has a static `options` list. If present, use it. Proceed to render normally.
-   > - **Stage 3 (Block):** Only if neither Stage 1 nor Stage 2 yields options, block the question. Display a notice that varies by sub-case: if the source question was answered but produced no usable values (empty or non-list result), tell the user that no options are available from that answer; if the source question has not been answered yet, tell the user to complete it first; if there is no `dynamic_options_source` at all (and no static `options` list), tell the user that no options are available and the question definition should be checked.
+   > - **Stage 1a (Dynamic, in-memory):** If the question has a `dynamic_options_source` field, look up the current in-memory answer for the `answer_title` referenced by that field. If the answer is non-empty (the source question has been answered in this session and contains list values), use those list values as the options. Proceed to render normally.
+   > - **Stage 1b (Dynamic, project files):** If Stage 1a finds nothing (source not yet answered in this session), search all `*.yaml` answer files saved under `projects/<project_name>/answers/` for a key matching `source_title`. If a non-empty list value is found, use it as the options. Record the file it came from (`resolved_source`) to show the user where the options originated. Proceed to render normally.
+   > - **Stage 2 (Static fallback):** If neither Stage 1a nor 1b yields options (either `dynamic_options_source` is absent, or the source key was not found anywhere), check whether the question has a static `options` list. If present, use it. Proceed to render normally.
+   > - **Stage 3 (Block):** Only if none of the above stages yield options, block the question. Display a notice that varies by sub-case: if the source question was answered in-memory but produced no usable values (empty or non-list result), tell the user that no options are available from that answer; if the source question has not been answered yet in any project file, tell the user to complete the blueprint that defines it first; if there is no `dynamic_options_source` at all (and no static `options` list), tell the user that no options are available and the question definition should be checked.
    >
-   > A question with both `dynamic_options_source` and a static `options` list is valid: Stage 1 takes priority when the source is answered; Stage 2 provides a graceful fallback when it is not. Never treat `dynamic_options_source` and `options` as mutually exclusive.
+   > A question with both `dynamic_options_source` and a static `options` list is valid: Stage 1a/1b take priority when the source is answered; Stage 2 provides a graceful fallback when it is not. Never treat `dynamic_options_source` and `options` as mutually exclusive.
 
    **Resolution algorithm (apply per question before display):**
 
@@ -646,22 +647,34 @@ Before presenting a step's details, check whether this step is the **first step 
    For each single-select / multi-select question:
 
      resolved_options = []
-     source_title = question.dynamic_options_source  # may be null/absent
+     resolved_source = null                            # tracks where options came from
+     source_title = question.dynamic_options_source    # may be null/absent
      source_was_answered = false
 
-     # Stage 1 — Dynamic (primary)
+     # Stage 1a — Dynamic, in-memory (current session)
      if source_title is present:
-       if source_title in in_memory_answers:           # key exists → source was answered
+       if source_title in in_memory_answers:           # key exists → source was answered this session
          source_answer = in_memory_answers[source_title]
          if source_answer is non-empty list:
            resolved_options = source_answer
+           resolved_source = "current answers"
          else:
            source_was_answered = true                  # answered but produced no usable options
+
+     # Stage 1b — Dynamic, project files (cross-blueprint lookup)
+     if resolved_options is empty and source_title is present and not source_was_answered:
+       for each yaml_file in glob("projects/<project_name>/answers/**/*.yaml"):
+         loaded = parse_yaml(yaml_file)
+         if source_title in loaded and loaded[source_title] is non-empty list:
+           resolved_options = loaded[source_title]
+           resolved_source = relative path of yaml_file
+           break
 
      # Stage 2 — Static fallback
      if resolved_options is empty:
        if question.options is present and non-empty:
          resolved_options = question.options
+         resolved_source = "question definition"
 
      # Stage 3 — Block
      if resolved_options is empty:
@@ -670,14 +683,16 @@ Before presenting a step's details, check whether this step is the **first step 
            Display: "⚠️ This question has no available options. '[source_title]'
                      was answered but produced no selectable values."
          elif source_title is present:
-           Display: "⚠️ This question cannot be answered yet. Please complete
-                     '[source_title]' first, then return to this question."
+           Display: "⚠️ This question cannot be answered yet. '[source_title]' was
+                     not found in the current session or in any saved answer files
+                     for project '<project_name>'. Complete the blueprint that
+                     defines '[source_title]' first, then return to this question."
          else:
            Display: "⚠️ This question has no available options and no dynamic
                      source is configured. Check the question definition."
        → Skip to next question
      else:
-       → Render question normally using resolved_options
+       → Render question normally using resolved_options and resolved_source
    ```
 
 5. **Present step information:**
@@ -704,41 +719,41 @@ Before presenting a step's details, check whether this step is the **first step 
     - **Type:** [answer_type: single-select, multi-select, list, or text]
     - **Guidance:** 
       [Full guidance text from definitions - all paragraphs and formatting]
-    [For single-select / multi-select questions — Stage 1 or Stage 2 resolved options:]
-    - **Available Options:**
-      1. [option 1 text]
-      2. [option 2 text]
-      ...
-    [For single-select / multi-select questions — Stage 3 blocked (source unanswered):]
-    ⚠️ This question cannot be answered yet. Please complete '[source_title]' first, then return to this question.
-    [For single-select / multi-select questions — Stage 3 blocked (source answered, no usable values):]
-    ⚠️ This question has no available options. '[source_title]' was answered but produced no selectable values.
-    [For single-select / multi-select questions — Stage 3 blocked (no dynamic source configured):]
-    ⚠️ This question has no available options and no dynamic source is configured. Check the question definition.
-    
-    ---
-    
-    ### Question 2: [question_text]
-    
-    **Answer:** [your answer]
-    
-    **Reasoning:** [why this answer was chosen based on user context]
-    
-    **Question Details:**
-    - **Type:** [answer_type]
-    - **Guidance:**
-      [Full guidance text from definitions - all paragraphs and formatting]
-    [For single-select / multi-select questions — Stage 1 or Stage 2 resolved options:]
-    - **Available Options:**
-      1. [option 1 text]
-      2. [option 2 text]
-      ...
-    [For single-select / multi-select questions — Stage 3 blocked (source unanswered):]
-    ⚠️ This question cannot be answered yet. Please complete '[source_title]' first, then return to this question.
-    [For single-select / multi-select questions — Stage 3 blocked (source answered, no usable values):]
-    ⚠️ This question has no available options. '[source_title]' was answered but produced no selectable values.
-    [For single-select / multi-select questions — Stage 3 blocked (no dynamic source configured):]
-    ⚠️ This question has no available options and no dynamic source is configured. Check the question definition.
+     [For single-select / multi-select questions — Stage 1a/1b or Stage 2 resolved options:]
+     - **Available Options** (from `[resolved_source]`):
+       1. [option 1 text]
+       2. [option 2 text]
+       ...
+     [For single-select / multi-select questions — Stage 3 blocked (source not found anywhere):]
+     ⚠️ This question cannot be answered yet. '[source_title]' was not found in the current session or in any saved answer files for project '<project_name>'. Complete the blueprint that defines '[source_title]' first, then return to this question.
+     [For single-select / multi-select questions — Stage 3 blocked (source answered, no usable values):]
+     ⚠️ This question has no available options. '[source_title]' was answered but produced no selectable values.
+     [For single-select / multi-select questions — Stage 3 blocked (no dynamic source configured):]
+     ⚠️ This question has no available options and no dynamic source is configured. Check the question definition.
+     
+     ---
+     
+     ### Question 2: [question_text]
+     
+     **Answer:** [your answer]
+     
+     **Reasoning:** [why this answer was chosen based on user context]
+     
+     **Question Details:**
+     - **Type:** [answer_type]
+     - **Guidance:**
+       [Full guidance text from definitions - all paragraphs and formatting]
+     [For single-select / multi-select questions — Stage 1a/1b or Stage 2 resolved options:]
+     - **Available Options** (from `[resolved_source]`):
+       1. [option 1 text]
+       2. [option 2 text]
+       ...
+     [For single-select / multi-select questions — Stage 3 blocked (source not found anywhere):]
+     ⚠️ This question cannot be answered yet. '[source_title]' was not found in the current session or in any saved answer files for project '<project_name>'. Complete the blueprint that defines '[source_title]' first, then return to this question.
+     [For single-select / multi-select questions — Stage 3 blocked (source answered, no usable values):]
+     ⚠️ This question has no available options. '[source_title]' was answered but produced no selectable values.
+     [For single-select / multi-select questions — Stage 3 blocked (no dynamic source configured):]
+     ⚠️ This question has no available options and no dynamic source is configured. Check the question definition.
    
    ---
    

--- a/.cortex/skills/blueprint-builder/SKILL.md
+++ b/.cortex/skills/blueprint-builder/SKILL.md
@@ -630,7 +630,47 @@ Before presenting a step's details, check whether this step is the **first step 
 
 3. **Load question details** from definitions/questions.yaml for all questions in this step
 
-4. **Present step information:**
+4. **Resolve options for single-select and multi-select questions** using the three-stage resolution below before presenting any question.
+
+   > **Maintainer note — Three-Stage Option Resolution:**
+   > For every single-select or multi-select question, options are resolved in this priority order:
+   > - **Stage 1 (Dynamic, primary):** If the question has a `dynamic_options_source` field, look up the current in-memory answer for the `answer_title` referenced by that field. If the answer is non-empty (the source question has been answered and contains list values), use those list values as the options. Proceed to render normally.
+   > - **Stage 2 (Static fallback):** If Stage 1 yields no options (either `dynamic_options_source` is absent, or the referenced source answer is empty/unanswered), check whether the question has a static `options` list. If present, use it. Proceed to render normally.
+   > - **Stage 3 (Block):** Only if neither Stage 1 nor Stage 2 yields options, block the question. Display a notice naming the source question (the `answer_title` from `dynamic_options_source`) that must be completed first.
+   >
+   > A question with both `dynamic_options_source` and a static `options` list is valid: Stage 1 takes priority when the source is answered; Stage 2 provides a graceful fallback when it is not. Never treat `dynamic_options_source` and `options` as mutually exclusive.
+
+   **Resolution algorithm (apply per question before display):**
+
+   ```
+   For each single-select / multi-select question:
+
+     resolved_options = []
+     source_title = question.dynamic_options_source  # may be null/absent
+
+     # Stage 1 — Dynamic (primary)
+     if source_title is present:
+       source_answer = in_memory_answers.get(source_title)
+       if source_answer is non-empty list:
+         resolved_options = source_answer
+
+     # Stage 2 — Static fallback
+     if resolved_options is empty:
+       if question.options is present and non-empty:
+         resolved_options = question.options
+
+     # Stage 3 — Block
+     if resolved_options is empty:
+       → Do NOT render the question for input
+       → Display blocking notice:
+         "⚠️ This question cannot be answered yet. Please complete
+          '[source_title]' first, then return to this question."
+       → Skip to next question
+     else:
+       → Render question normally using resolved_options
+   ```
+
+5. **Present step information:**
    ```
    ======================================================================
     Step [N] of [Total]: [Step Name]
@@ -644,39 +684,43 @@ Before presenting a step's details, check whether this step is the **first step 
    
    ## Configuration Questions and Answers
    
-   ### Question 1: [question_text]
-   
-   **Answer:** [your answer]
-   
-   **Reasoning:** [why this answer was chosen based on user context]
-   
-   **Question Details:**
-   - **Type:** [answer_type: multi-select, list, or text]
-   - **Guidance:** 
-     [Full guidance text from definitions - all paragraphs and formatting]
-   [For multi-select questions:]
-   - **Available Options:**
-     1. [option 1 text]
-     2. [option 2 text]
-     ...
-   
-   ---
-   
-   ### Question 2: [question_text]
-   
-   **Answer:** [your answer]
-   
-   **Reasoning:** [why this answer was chosen based on user context]
-   
-   **Question Details:**
-   - **Type:** [answer_type]
-   - **Guidance:**
-     [Full guidance text from definitions - all paragraphs and formatting]
-   [For multi-select questions:]
-   - **Available Options:**
-     1. [option 1 text]
-     2. [option 2 text]
-     ...
+    ### Question 1: [question_text]
+    
+    **Answer:** [your answer]
+    
+    **Reasoning:** [why this answer was chosen based on user context]
+    
+    **Question Details:**
+    - **Type:** [answer_type: single-select, multi-select, list, or text]
+    - **Guidance:** 
+      [Full guidance text from definitions - all paragraphs and formatting]
+    [For single-select / multi-select questions — Stage 1 or Stage 2 resolved options:]
+    - **Available Options:**
+      1. [option 1 text]
+      2. [option 2 text]
+      ...
+    [For single-select / multi-select questions — Stage 3 blocked (no dynamic or static options available):]
+    ⚠️ This question cannot be answered yet. Please complete '[source_title]' first, then return to this question.
+    
+    ---
+    
+    ### Question 2: [question_text]
+    
+    **Answer:** [your answer]
+    
+    **Reasoning:** [why this answer was chosen based on user context]
+    
+    **Question Details:**
+    - **Type:** [answer_type]
+    - **Guidance:**
+      [Full guidance text from definitions - all paragraphs and formatting]
+    [For single-select / multi-select questions — Stage 1 or Stage 2 resolved options:]
+    - **Available Options:**
+      1. [option 1 text]
+      2. [option 2 text]
+      ...
+    [For single-select / multi-select questions — Stage 3 blocked (no dynamic or static options available):]
+    ⚠️ This question cannot be answered yet. Please complete '[source_title]' first, then return to this question.
    
    ---
    

--- a/definitions/questions.yaml
+++ b/definitions/questions.yaml
@@ -403,6 +403,7 @@
 - answer_title: data_product_environment
   question_text: Which environment is this data product being deployed to?
   answer_type: single-select
+  dynamic_options_source: environment_list
   is_org_scope: false
   guidance: '**What is this asking?**
 
@@ -458,6 +459,7 @@
 - answer_title: data_product_domain
   question_text: Which domain does this data product belong to?
   answer_type: single-select
+  dynamic_options_source: domain_list
   is_org_scope: false
   guidance: '**What is this asking?**
 
@@ -1774,6 +1776,7 @@
 - answer_title: account_environment
   question_text: Which environment will this account represent?
   answer_type: single-select
+  dynamic_options_source: environment_list
   is_org_scope: false
   guidance: '**What is this asking?**
 
@@ -1834,6 +1837,7 @@
 - answer_title: account_domain
   question_text: Which domain will this account represent?
   answer_type: single-select
+  dynamic_options_source: domain_list
   is_org_scope: false
   guidance: '**What is this asking?**
 


### PR DESCRIPTION
# PR Overview: Update blueprint-builder SKILL.md with three-stage option resolution logic

## Description and Motivation

Step 7.1 ("Display Step Overview and Questions") in `.cortex/skills/blueprint-builder/SKILL.md` previously used a two-branch model that treated `dynamic_options_source` and `options` as mutually exclusive — a question either had dynamic options or static options, but not both.

This PR replaces that logic with a **three-stage option resolution** for single-select and multi-select questions:

- **Stage 1 — Dynamic (primary):** If the question has a `dynamic_options_source` field and the referenced source answer is non-empty, use those list values as options.
- **Stage 2 — Static fallback:** If Stage 1 yields no options, fall back to the question's static `options` list (if present).
- **Stage 3 — Block:** Only if neither Stage 1 nor Stage 2 yields options, block the question and display a notice naming the source question the user must complete first.

This change enables questions to have both `dynamic_options_source` and a static `options` list simultaneously — Stage 1 takes priority when the source is answered, and Stage 2 provides a graceful fallback when it is not. Questions with only a static `options` list (no `dynamic_options_source`) are entirely unaffected.

A maintainer note and pseudocode algorithm are also added near the updated logic for documentation purposes.

## Linked Ticket

- **CXE-15276** — Update blueprint-builder SKILL.md with three-stage option resolution logic
- **Parent: CXE-15208** — Add support for dynamic options for single/multi-select questions

## Local Testing Performed

- Read the full diff of `.cortex/skills/blueprint-builder/SKILL.md` to verify:
  - The three-stage algorithm block is correctly placed before the question display template (new step 4).
  - The maintainer note accurately describes Stage 1 / Stage 2 / Stage 3 behavior.
  - The question display template is updated to show both the "options resolved" path and the "Stage 3 blocked" path for single-select / multi-select questions.
  - The old two-branch logic that treated `dynamic_options_source` and `options` as mutually exclusive is fully removed.
  - Questions with only a static `options` list are unaffected by the new logic.

## How Reviewer Can Test

1. Check out this branch and open `.cortex/skills/blueprint-builder/SKILL.md`.
2. Navigate to **Step 7.1 — Display Step Overview and Questions** (around the `## Configuration Questions and Answers` section).
3. Verify the new step 4 contains:
   - A maintainer note (blockquote) explaining the three-stage resolution.
   - A pseudocode algorithm block showing the `resolved_options` logic for Stage 1 → Stage 2 → Stage 3.
4. Verify the question display template shows:
   - `[For single-select / multi-select questions — Stage 1 or Stage 2 resolved options:]` with an **Available Options** list.
   - `[For single-select / multi-select questions — Stage 3 blocked ...]` with the blocking notice including `[source_title]`.
5. Confirm the old two-branch logic (treating `dynamic_options_source` and `options` as mutually exclusive) is gone.

Acceptance criteria to verify against:

| Scenario | Expected behavior |
|---|---|
| Question with only `dynamic_options_source`, source answered | Dynamic values presented as options (Stage 1) |
| Question with only `dynamic_options_source`, source unanswered | Blocking notice naming the source question (Stage 3) |
| Question with both `dynamic_options_source` and `options`, source answered | Dynamic values presented (Stage 1 takes priority) |
| Question with both `dynamic_options_source` and `options`, source unanswered | Static `options` list presented (Stage 2 fallback, no blocking) |
| Question with only `options` (no `dynamic_options_source`) | Behavior unchanged |

## Config / Migration Steps

None. This change only updates the skill instruction document (`SKILL.md`). No data migrations, configuration changes, or dependency updates are required.

## Breaking Changes

None. The three-stage logic is a strict superset of the previous behavior:
- Existing questions with only a static `options` list pass straight through Stage 1 (no `dynamic_options_source` present) and Stage 2 (static options found) — identical to before.
- The only behavioral change affects questions that will gain a `dynamic_options_source` field in `questions.yaml` (a separate, follow-on task not in scope for this PR).

## Screenshots / Recordings

N/A — this is a documentation/instruction update with no UI changes.
