### PR TITLE
sync: SCIM network policy, object-list keys, and guidance improvements

### DIFF
--- a/blueprints/account-creation/configure-account-scim-integration/dynamic.md.jinja
+++ b/blueprints/account-creation/configure-account-scim-integration/dynamic.md.jinja
@@ -20,9 +20,15 @@ A network policy will be created to restrict SCIM access to these IP addresses:
 | {{ ip }} |
 {%- endfor %}
 
+{%- if identity_provider in ["Microsoft Entra ID (Azure AD)", "Okta"] %}
+
+> **Note:** {{ identity_provider }} outbound IP addresses change over time (Azure AD: weekly; Okta: unpredictably). This static list will require periodic maintenance to avoid SCIM provisioning failures. The SCIM bearer token alone is sufficient for authentication — consider removing these IPs to reduce operational overhead.
+
+{%- endif %}
+
 {%- else %}
 
-No SCIM network policy will be created. Consider adding one for improved security.
+No SCIM network policy will be created. The SCIM bearer token provides sufficient authentication.{% if identity_provider in ["Microsoft Entra ID (Azure AD)", "Okta"] %} For {{ identity_provider }}, this is the recommended approach — their outbound IP addresses change over time, making static IP lists difficult to maintain reliably.{% endif %}
 
 {%- endif %}
 

--- a/blueprints/account-creation/configure-account-scim-integration/overview.md
+++ b/blueprints/account-creation/configure-account-scim-integration/overview.md
@@ -112,17 +112,18 @@ Use the suggested name from the previous step unless you have a specific reason 
 
 #### What IP addresses should be allowed for SCIM provisioning? (`account_scim_allowed_ips`: list)
 **What is this asking?**
-Enter the IP addresses from which your Identity Provider will make SCIM API calls to Snowflake. This creates a network policy that restricts SCIM access.
+Enter the IP addresses from which your Identity Provider will make SCIM API calls to Snowflake. This creates a network policy that restricts SCIM access to those IPs.
+
+**Recommendation for Azure AD and Okta: leave this empty.**
+Azure AD (Entra ID) IP addresses change on a weekly schedule and Okta IPs change unpredictably — a static IP list will drift out of date and break SCIM provisioning. The SCIM bearer token is the primary authentication mechanism and is sufficient on its own. Skipping the network policy avoids ongoing maintenance burden without meaningfully reducing security.
+Only provide IPs if your IdP uses a stable, known set of outbound addresses (e.g. on-premises or private-network IdPs).
 
 **If using Organization Configuration:**
 Use the same IdP IP addresses as your Organization Account for consistency.
 
-**Why does this matter?**
-Restricting SCIM access to known IdP IPs prevents unauthorized provisioning attempts.
-
-**How to find your IdP's IP ranges:**
-- **Okta**: [Okta IP Addresses](https://help.okta.com/en-us/Content/Topics/Security/IP-Ranges.htm)
-- **Azure AD**: [Azure AD IP Ranges](https://docs.microsoft.com/en-us/azure/active-directory/enterprise-users/directory-service-limits-restrictions)
+**How to find your IdP's IP ranges (if needed):**
+- **Okta**: [Okta IP Ranges](https://help.okta.com/en-us/Content/Topics/Security/IP-Ranges.htm) — use the ranges for your Okta cell only; note these change without notice
+- **Azure AD**: [Azure Service Tags](https://www.microsoft.com/en-us/download/details.aspx?id=56519) — look for the AzureActiveDirectory tag; updated weekly by Microsoft
 
 **Format:**
 Enter each IP address or CIDR block on a separate line:
@@ -130,8 +131,6 @@ Enter each IP address or CIDR block on a separate line:
 203.0.113.0/24
 198.51.100.1
 ```
-
-**Important:** If you don't know your IdP's IP ranges, you can skip the network policy and add it later. However, this is a security best practice.
 
 **More Information:**
 * [Network Policies](https://docs.snowflake.com/en/user-guide/network-policies) — IP-based access control

--- a/blueprints/account-creation/create-account-administrators/overview.md
+++ b/blueprints/account-creation/create-account-administrators/overview.md
@@ -111,6 +111,7 @@ We strongly recommend using the user's **email address** as the `login_name`, ev
 Users are created automatically from your IdP. You only need to specify:
 - **login_name**: The username as it appears in Snowflake (typically the email address—check `SHOW USERS;` after SCIM sync)
 - **admin_role**: The administrative role to assign
+- **user_identifier** *(optional)*: The exact Snowflake username to use when granting roles. If your IdP provisions usernames differently from `login_name` (e.g., Snowflake stores `JOHN.DOE@COMPANY.COM` but `login_name` was entered as `john.doe@company.com`), set this to the value shown in `SHOW USERS;`. Falls back to `login_name` if not provided.
 
 Leave `email`, `first_name`, and `last_name` blank for SCIM users—these are managed by your IdP.
 
@@ -121,6 +122,7 @@ Users will be created directly in Snowflake. Provide:
 - **email**: Email address for notifications (can match login_name)
 - **first_name**: User's first name
 - **last_name**: User's last name
+- **user_identifier** *(optional)*: Override the identifier used in `CREATE USER` and `GRANT ROLE` statements. Useful when the desired Snowflake username contains `@` or `.` and needs to be quoted, or differs from the login name. Falls back to `login_name` if not provided.
 
 **Admin Role Options:**
 | Role | Responsibility | Recommended For |

--- a/blueprints/account-creation/enable-account-multi-factor-authentication/overview.md
+++ b/blueprints/account-creation/enable-account-multi-factor-authentication/overview.md
@@ -83,6 +83,7 @@ We strongly recommend using the user's **email address** as the `login_name`, ev
 Users are created automatically from your IdP. You only need to specify:
 - **login_name**: The username as it appears in Snowflake (typically the email address—check `SHOW USERS;` after SCIM sync)
 - **admin_role**: The administrative role to assign
+- **user_identifier** *(optional)*: The exact Snowflake username to use when granting roles. If your IdP provisions usernames differently from `login_name` (e.g., Snowflake stores `JOHN.DOE@COMPANY.COM` but `login_name` was entered as `john.doe@company.com`), set this to the value shown in `SHOW USERS;`. Falls back to `login_name` if not provided.
 
 Leave `email`, `first_name`, and `last_name` blank for SCIM users—these are managed by your IdP.
 
@@ -93,6 +94,7 @@ Users will be created directly in Snowflake. Provide:
 - **email**: Email address for notifications (can match login_name)
 - **first_name**: User's first name
 - **last_name**: User's last name
+- **user_identifier** *(optional)*: Override the identifier used in `CREATE USER` and `GRANT ROLE` statements. Useful when the desired Snowflake username contains `@` or `.` and needs to be quoted, or differs from the login name. Falls back to `login_name` if not provided.
 
 **Admin Role Options:**
 | Role | Responsibility | Recommended For |

--- a/blueprints/data-product-setup/assign-monitors-to-warehouses/overview.md
+++ b/blueprints/data-product-setup/assign-monitors-to-warehouses/overview.md
@@ -218,26 +218,35 @@ For environment-based and domain+environment strategies, select the environment 
 **What is this asking?**
 Define compute warehouses for your data product workloads.
 
+**Field Descriptions:**
+- **name**: Short identifier used in Snowflake object names (e.g. `ETL` → `PREFIX_WH_ETL`). Uppercase, no spaces.
+- **workload**: Functional label describing the workload type (e.g. `ETL`, `ANALYTICS`, `INTERACTIVE`). Used in planning summaries and warehouse tags.
+- **size**: Warehouse size (X-Small, Small, Medium, Large, X-Large, 2X-Large).
+- **min_cluster_count** / **max_cluster_count**: Multi-cluster range. Use 1/1 for single-cluster.
+- **auto_suspend_seconds**: Seconds of inactivity before auto-suspend (60–600 recommended).
+- **timeout_minutes**: Query timeout in minutes. Queries exceeding this are cancelled (e.g. `30`).
+- **comment**: Human-readable description of the warehouse's purpose.
+
 **Common Patterns:**
 
 **Simple (1 warehouse):**
-| Name | Size | Min/Max Clusters | Auto-Suspend |
-|------|------|------------------|--------------|
-| GENERAL | Small | 1/1 | 300 |
+| Name | Workload | Size | Min/Max | Auto-Suspend | Timeout (min) | Comment |
+|------|----------|------|---------|--------------|---------------|---------|
+| GENERAL | GENERAL | Small | 1/1 | 300 | 30 | General purpose warehouse |
 
 **Standard (2-3 warehouses):**
-| Name | Size | Min/Max Clusters | Auto-Suspend |
-|------|------|------------------|--------------|
-| ETL | Medium | 1/3 | 60 |
-| QUERY | Small | 1/2 | 300 |
+| Name | Workload | Size | Min/Max | Auto-Suspend | Timeout (min) | Comment |
+|------|----------|------|---------|--------------|---------------|---------|
+| ETL | ETL | Medium | 1/3 | 60 | 120 | Batch ingestion and transformation |
+| QUERY | INTERACTIVE | Small | 1/2 | 300 | 30 | Ad-hoc and BI queries |
 
 **Advanced (workload isolation):**
-| Name | Size | Min/Max Clusters | Auto-Suspend |
-|------|------|------------------|--------------|
-| INGEST | Large | 1/3 | 60 |
-| TRANSFORM | Medium | 1/3 | 120 |
-| INTERACTIVE | Small | 1/2 | 300 |
-| REPORTING | Medium | 1/4 | 300 |
+| Name | Workload | Size | Min/Max | Auto-Suspend | Timeout (min) | Comment |
+|------|----------|------|---------|--------------|---------------|---------|
+| INGEST | INGEST | Large | 1/3 | 60 | 240 | High-volume data loading |
+| TRANSFORM | ETL | Medium | 1/3 | 120 | 120 | dbt and transformation jobs |
+| INTERACTIVE | INTERACTIVE | Small | 1/2 | 300 | 30 | Analyst queries |
+| REPORTING | REPORTING | Medium | 1/4 | 300 | 60 | BI tool queries |
 
 **Sizing Guidelines:**
 - X-Small/Small: Development, light queries

--- a/blueprints/data-product-setup/configure-alert-notifications/overview.md
+++ b/blueprints/data-product-setup/configure-alert-notifications/overview.md
@@ -274,26 +274,35 @@ stages in your data pipeline.
 **What is this asking?**
 Define compute warehouses for your data product workloads.
 
+**Field Descriptions:**
+- **name**: Short identifier used in Snowflake object names (e.g. `ETL` → `PREFIX_WH_ETL`). Uppercase, no spaces.
+- **workload**: Functional label describing the workload type (e.g. `ETL`, `ANALYTICS`, `INTERACTIVE`). Used in planning summaries and warehouse tags.
+- **size**: Warehouse size (X-Small, Small, Medium, Large, X-Large, 2X-Large).
+- **min_cluster_count** / **max_cluster_count**: Multi-cluster range. Use 1/1 for single-cluster.
+- **auto_suspend_seconds**: Seconds of inactivity before auto-suspend (60–600 recommended).
+- **timeout_minutes**: Query timeout in minutes. Queries exceeding this are cancelled (e.g. `30`).
+- **comment**: Human-readable description of the warehouse's purpose.
+
 **Common Patterns:**
 
 **Simple (1 warehouse):**
-| Name | Size | Min/Max Clusters | Auto-Suspend |
-|------|------|------------------|--------------|
-| GENERAL | Small | 1/1 | 300 |
+| Name | Workload | Size | Min/Max | Auto-Suspend | Timeout (min) | Comment |
+|------|----------|------|---------|--------------|---------------|---------|
+| GENERAL | GENERAL | Small | 1/1 | 300 | 30 | General purpose warehouse |
 
 **Standard (2-3 warehouses):**
-| Name | Size | Min/Max Clusters | Auto-Suspend |
-|------|------|------------------|--------------|
-| ETL | Medium | 1/3 | 60 |
-| QUERY | Small | 1/2 | 300 |
+| Name | Workload | Size | Min/Max | Auto-Suspend | Timeout (min) | Comment |
+|------|----------|------|---------|--------------|---------------|---------|
+| ETL | ETL | Medium | 1/3 | 60 | 120 | Batch ingestion and transformation |
+| QUERY | INTERACTIVE | Small | 1/2 | 300 | 30 | Ad-hoc and BI queries |
 
 **Advanced (workload isolation):**
-| Name | Size | Min/Max Clusters | Auto-Suspend |
-|------|------|------------------|--------------|
-| INGEST | Large | 1/3 | 60 |
-| TRANSFORM | Medium | 1/3 | 120 |
-| INTERACTIVE | Small | 1/2 | 300 |
-| REPORTING | Medium | 1/4 | 300 |
+| Name | Workload | Size | Min/Max | Auto-Suspend | Timeout (min) | Comment |
+|------|----------|------|---------|--------------|---------------|---------|
+| INGEST | INGEST | Large | 1/3 | 60 | 240 | High-volume data loading |
+| TRANSFORM | ETL | Medium | 1/3 | 120 | 120 | dbt and transformation jobs |
+| INTERACTIVE | INTERACTIVE | Small | 1/2 | 300 | 30 | Analyst queries |
+| REPORTING | REPORTING | Medium | 1/4 | 300 | 60 | BI tool queries |
 
 **Sizing Guidelines:**
 - X-Small/Small: Development, light queries

--- a/blueprints/data-product-setup/create-schemas/overview.md
+++ b/blueprints/data-product-setup/create-schemas/overview.md
@@ -223,30 +223,19 @@ For environment-based and domain+environment strategies, select the environment 
 
 #### Define the schemas for each zone in your data product. (`schema_configuration`: object-list)
 **What is this asking?**
-Define schemas within each zone. Schemas organize tables by source system 
-or subject area.
+Define schemas for each zone in your data product. Each row represents one zone, and `schemas` is a comma-separated list of schema names that belong to that zone.
 
 **Example Configuration:**
 
-**RAW Zone:**
-| Schema | Purpose |
-|--------|---------|
-| SALESFORCE | Salesforce CRM data |
-| SAP | SAP ERP data |
-| STRIPE | Payment processing data |
+| Zone | Schemas |
+|------|---------|
+| RAW | SALESFORCE, SAP, STRIPE |
+| CURATED | CUSTOMERS, ORDERS, PRODUCTS |
+| CONSUMPTION | REPORTING, ANALYTICS |
 
-**CURATED Zone:**
-| Schema | Purpose |
-|--------|---------|
-| CUSTOMERS | Unified customer data |
-| ORDERS | Order history |
-| PRODUCTS | Product catalog |
-
-**CONSUMPTION Zone:**
-| Schema | Purpose |
-|--------|---------|
-| REPORTING | BI-ready tables |
-| ANALYTICS | Aggregations and metrics |
+**Field Descriptions:**
+- **zone**: The data zone this entry applies to (e.g. RAW, CURATED, CONSUMPTION). Must match a zone defined in your data architecture.
+- **schemas**: Comma-separated list of schema names for this zone (e.g. `SALESFORCE, SAP, STRIPE`). Each schema name should be uppercase and contain only letters, numbers, and underscores.
 
 **Best Practices:**
 - Use consistent naming across zones

--- a/blueprints/data-product-setup/create-warehouse-access-roles/overview.md
+++ b/blueprints/data-product-setup/create-warehouse-access-roles/overview.md
@@ -218,26 +218,35 @@ For environment-based and domain+environment strategies, select the environment 
 **What is this asking?**
 Define compute warehouses for your data product workloads.
 
+**Field Descriptions:**
+- **name**: Short identifier used in Snowflake object names (e.g. `ETL` → `PREFIX_WH_ETL`). Uppercase, no spaces.
+- **workload**: Functional label describing the workload type (e.g. `ETL`, `ANALYTICS`, `INTERACTIVE`). Used in planning summaries and warehouse tags.
+- **size**: Warehouse size (X-Small, Small, Medium, Large, X-Large, 2X-Large).
+- **min_cluster_count** / **max_cluster_count**: Multi-cluster range. Use 1/1 for single-cluster.
+- **auto_suspend_seconds**: Seconds of inactivity before auto-suspend (60–600 recommended).
+- **timeout_minutes**: Query timeout in minutes. Queries exceeding this are cancelled (e.g. `30`).
+- **comment**: Human-readable description of the warehouse's purpose.
+
 **Common Patterns:**
 
 **Simple (1 warehouse):**
-| Name | Size | Min/Max Clusters | Auto-Suspend |
-|------|------|------------------|--------------|
-| GENERAL | Small | 1/1 | 300 |
+| Name | Workload | Size | Min/Max | Auto-Suspend | Timeout (min) | Comment |
+|------|----------|------|---------|--------------|---------------|---------|
+| GENERAL | GENERAL | Small | 1/1 | 300 | 30 | General purpose warehouse |
 
 **Standard (2-3 warehouses):**
-| Name | Size | Min/Max Clusters | Auto-Suspend |
-|------|------|------------------|--------------|
-| ETL | Medium | 1/3 | 60 |
-| QUERY | Small | 1/2 | 300 |
+| Name | Workload | Size | Min/Max | Auto-Suspend | Timeout (min) | Comment |
+|------|----------|------|---------|--------------|---------------|---------|
+| ETL | ETL | Medium | 1/3 | 60 | 120 | Batch ingestion and transformation |
+| QUERY | INTERACTIVE | Small | 1/2 | 300 | 30 | Ad-hoc and BI queries |
 
 **Advanced (workload isolation):**
-| Name | Size | Min/Max Clusters | Auto-Suspend |
-|------|------|------------------|--------------|
-| INGEST | Large | 1/3 | 60 |
-| TRANSFORM | Medium | 1/3 | 120 |
-| INTERACTIVE | Small | 1/2 | 300 |
-| REPORTING | Medium | 1/4 | 300 |
+| Name | Workload | Size | Min/Max | Auto-Suspend | Timeout (min) | Comment |
+|------|----------|------|---------|--------------|---------------|---------|
+| INGEST | INGEST | Large | 1/3 | 60 | 240 | High-volume data loading |
+| TRANSFORM | ETL | Medium | 1/3 | 120 | 120 | dbt and transformation jobs |
+| INTERACTIVE | INTERACTIVE | Small | 1/2 | 300 | 30 | Analyst queries |
+| REPORTING | REPORTING | Medium | 1/4 | 300 | 60 | BI tool queries |
 
 **Sizing Guidelines:**
 - X-Small/Small: Development, light queries

--- a/blueprints/data-product-setup/create-warehouses/overview.md
+++ b/blueprints/data-product-setup/create-warehouses/overview.md
@@ -222,26 +222,35 @@ For environment-based and domain+environment strategies, select the environment 
 **What is this asking?**
 Define compute warehouses for your data product workloads.
 
+**Field Descriptions:**
+- **name**: Short identifier used in Snowflake object names (e.g. `ETL` → `PREFIX_WH_ETL`). Uppercase, no spaces.
+- **workload**: Functional label describing the workload type (e.g. `ETL`, `ANALYTICS`, `INTERACTIVE`). Used in planning summaries and warehouse tags.
+- **size**: Warehouse size (X-Small, Small, Medium, Large, X-Large, 2X-Large).
+- **min_cluster_count** / **max_cluster_count**: Multi-cluster range. Use 1/1 for single-cluster.
+- **auto_suspend_seconds**: Seconds of inactivity before auto-suspend (60–600 recommended).
+- **timeout_minutes**: Query timeout in minutes. Queries exceeding this are cancelled (e.g. `30`).
+- **comment**: Human-readable description of the warehouse's purpose.
+
 **Common Patterns:**
 
 **Simple (1 warehouse):**
-| Name | Size | Min/Max Clusters | Auto-Suspend |
-|------|------|------------------|--------------|
-| GENERAL | Small | 1/1 | 300 |
+| Name | Workload | Size | Min/Max | Auto-Suspend | Timeout (min) | Comment |
+|------|----------|------|---------|--------------|---------------|---------|
+| GENERAL | GENERAL | Small | 1/1 | 300 | 30 | General purpose warehouse |
 
 **Standard (2-3 warehouses):**
-| Name | Size | Min/Max Clusters | Auto-Suspend |
-|------|------|------------------|--------------|
-| ETL | Medium | 1/3 | 60 |
-| QUERY | Small | 1/2 | 300 |
+| Name | Workload | Size | Min/Max | Auto-Suspend | Timeout (min) | Comment |
+|------|----------|------|---------|--------------|---------------|---------|
+| ETL | ETL | Medium | 1/3 | 60 | 120 | Batch ingestion and transformation |
+| QUERY | INTERACTIVE | Small | 1/2 | 300 | 30 | Ad-hoc and BI queries |
 
 **Advanced (workload isolation):**
-| Name | Size | Min/Max Clusters | Auto-Suspend |
-|------|------|------------------|--------------|
-| INGEST | Large | 1/3 | 60 |
-| TRANSFORM | Medium | 1/3 | 120 |
-| INTERACTIVE | Small | 1/2 | 300 |
-| REPORTING | Medium | 1/4 | 300 |
+| Name | Workload | Size | Min/Max | Auto-Suspend | Timeout (min) | Comment |
+|------|----------|------|---------|--------------|---------------|---------|
+| INGEST | INGEST | Large | 1/3 | 60 | 240 | High-volume data loading |
+| TRANSFORM | ETL | Medium | 1/3 | 120 | 120 | dbt and transformation jobs |
+| INTERACTIVE | INTERACTIVE | Small | 1/2 | 300 | 30 | Analyst queries |
+| REPORTING | REPORTING | Medium | 1/4 | 300 | 60 | BI tool queries |
 
 **Sizing Guidelines:**
 - X-Small/Small: Development, light queries

--- a/blueprints/data-product-setup/grant-database-access-to-roles/overview.md
+++ b/blueprints/data-product-setup/grant-database-access-to-roles/overview.md
@@ -240,26 +240,35 @@ the standard functional roles (WRITE, CREATE).
 **What is this asking?**
 Define compute warehouses for your data product workloads.
 
+**Field Descriptions:**
+- **name**: Short identifier used in Snowflake object names (e.g. `ETL` → `PREFIX_WH_ETL`). Uppercase, no spaces.
+- **workload**: Functional label describing the workload type (e.g. `ETL`, `ANALYTICS`, `INTERACTIVE`). Used in planning summaries and warehouse tags.
+- **size**: Warehouse size (X-Small, Small, Medium, Large, X-Large, 2X-Large).
+- **min_cluster_count** / **max_cluster_count**: Multi-cluster range. Use 1/1 for single-cluster.
+- **auto_suspend_seconds**: Seconds of inactivity before auto-suspend (60–600 recommended).
+- **timeout_minutes**: Query timeout in minutes. Queries exceeding this are cancelled (e.g. `30`).
+- **comment**: Human-readable description of the warehouse's purpose.
+
 **Common Patterns:**
 
 **Simple (1 warehouse):**
-| Name | Size | Min/Max Clusters | Auto-Suspend |
-|------|------|------------------|--------------|
-| GENERAL | Small | 1/1 | 300 |
+| Name | Workload | Size | Min/Max | Auto-Suspend | Timeout (min) | Comment |
+|------|----------|------|---------|--------------|---------------|---------|
+| GENERAL | GENERAL | Small | 1/1 | 300 | 30 | General purpose warehouse |
 
 **Standard (2-3 warehouses):**
-| Name | Size | Min/Max Clusters | Auto-Suspend |
-|------|------|------------------|--------------|
-| ETL | Medium | 1/3 | 60 |
-| QUERY | Small | 1/2 | 300 |
+| Name | Workload | Size | Min/Max | Auto-Suspend | Timeout (min) | Comment |
+|------|----------|------|---------|--------------|---------------|---------|
+| ETL | ETL | Medium | 1/3 | 60 | 120 | Batch ingestion and transformation |
+| QUERY | INTERACTIVE | Small | 1/2 | 300 | 30 | Ad-hoc and BI queries |
 
 **Advanced (workload isolation):**
-| Name | Size | Min/Max Clusters | Auto-Suspend |
-|------|------|------------------|--------------|
-| INGEST | Large | 1/3 | 60 |
-| TRANSFORM | Medium | 1/3 | 120 |
-| INTERACTIVE | Small | 1/2 | 300 |
-| REPORTING | Medium | 1/4 | 300 |
+| Name | Workload | Size | Min/Max | Auto-Suspend | Timeout (min) | Comment |
+|------|----------|------|---------|--------------|---------------|---------|
+| INGEST | INGEST | Large | 1/3 | 60 | 240 | High-volume data loading |
+| TRANSFORM | ETL | Medium | 1/3 | 120 | 120 | dbt and transformation jobs |
+| INTERACTIVE | INTERACTIVE | Small | 1/2 | 300 | 30 | Analyst queries |
+| REPORTING | REPORTING | Medium | 1/4 | 300 | 60 | BI tool queries |
 
 **Sizing Guidelines:**
 - X-Small/Small: Development, light queries

--- a/blueprints/data-product-setup/plan-schema-organization/overview.md
+++ b/blueprints/data-product-setup/plan-schema-organization/overview.md
@@ -100,30 +100,19 @@ Choose a name that business users would recognize. Ask: "If someone searched for
 
 #### Define the schemas for each zone in your data product. (`schema_configuration`: object-list)
 **What is this asking?**
-Define schemas within each zone. Schemas organize tables by source system 
-or subject area.
+Define schemas for each zone in your data product. Each row represents one zone, and `schemas` is a comma-separated list of schema names that belong to that zone.
 
 **Example Configuration:**
 
-**RAW Zone:**
-| Schema | Purpose |
-|--------|---------|
-| SALESFORCE | Salesforce CRM data |
-| SAP | SAP ERP data |
-| STRIPE | Payment processing data |
+| Zone | Schemas |
+|------|---------|
+| RAW | SALESFORCE, SAP, STRIPE |
+| CURATED | CUSTOMERS, ORDERS, PRODUCTS |
+| CONSUMPTION | REPORTING, ANALYTICS |
 
-**CURATED Zone:**
-| Schema | Purpose |
-|--------|---------|
-| CUSTOMERS | Unified customer data |
-| ORDERS | Order history |
-| PRODUCTS | Product catalog |
-
-**CONSUMPTION Zone:**
-| Schema | Purpose |
-|--------|---------|
-| REPORTING | BI-ready tables |
-| ANALYTICS | Aggregations and metrics |
+**Field Descriptions:**
+- **zone**: The data zone this entry applies to (e.g. RAW, CURATED, CONSUMPTION). Must match a zone defined in your data architecture.
+- **schemas**: Comma-separated list of schema names for this zone (e.g. `SALESFORCE, SAP, STRIPE`). Each schema name should be uppercase and contain only letters, numbers, and underscores.
 
 **Best Practices:**
 - Use consistent naming across zones

--- a/blueprints/data-product-setup/plan-warehouse-requirements/overview.md
+++ b/blueprints/data-product-setup/plan-warehouse-requirements/overview.md
@@ -101,26 +101,35 @@ Choose a name that business users would recognize. Ask: "If someone searched for
 **What is this asking?**
 Define compute warehouses for your data product workloads.
 
+**Field Descriptions:**
+- **name**: Short identifier used in Snowflake object names (e.g. `ETL` → `PREFIX_WH_ETL`). Uppercase, no spaces.
+- **workload**: Functional label describing the workload type (e.g. `ETL`, `ANALYTICS`, `INTERACTIVE`). Used in planning summaries and warehouse tags.
+- **size**: Warehouse size (X-Small, Small, Medium, Large, X-Large, 2X-Large).
+- **min_cluster_count** / **max_cluster_count**: Multi-cluster range. Use 1/1 for single-cluster.
+- **auto_suspend_seconds**: Seconds of inactivity before auto-suspend (60–600 recommended).
+- **timeout_minutes**: Query timeout in minutes. Queries exceeding this are cancelled (e.g. `30`).
+- **comment**: Human-readable description of the warehouse's purpose.
+
 **Common Patterns:**
 
 **Simple (1 warehouse):**
-| Name | Size | Min/Max Clusters | Auto-Suspend |
-|------|------|------------------|--------------|
-| GENERAL | Small | 1/1 | 300 |
+| Name | Workload | Size | Min/Max | Auto-Suspend | Timeout (min) | Comment |
+|------|----------|------|---------|--------------|---------------|---------|
+| GENERAL | GENERAL | Small | 1/1 | 300 | 30 | General purpose warehouse |
 
 **Standard (2-3 warehouses):**
-| Name | Size | Min/Max Clusters | Auto-Suspend |
-|------|------|------------------|--------------|
-| ETL | Medium | 1/3 | 60 |
-| QUERY | Small | 1/2 | 300 |
+| Name | Workload | Size | Min/Max | Auto-Suspend | Timeout (min) | Comment |
+|------|----------|------|---------|--------------|---------------|---------|
+| ETL | ETL | Medium | 1/3 | 60 | 120 | Batch ingestion and transformation |
+| QUERY | INTERACTIVE | Small | 1/2 | 300 | 30 | Ad-hoc and BI queries |
 
 **Advanced (workload isolation):**
-| Name | Size | Min/Max Clusters | Auto-Suspend |
-|------|------|------------------|--------------|
-| INGEST | Large | 1/3 | 60 |
-| TRANSFORM | Medium | 1/3 | 120 |
-| INTERACTIVE | Small | 1/2 | 300 |
-| REPORTING | Medium | 1/4 | 300 |
+| Name | Workload | Size | Min/Max | Auto-Suspend | Timeout (min) | Comment |
+|------|----------|------|---------|--------------|---------------|---------|
+| INGEST | INGEST | Large | 1/3 | 60 | 240 | High-volume data loading |
+| TRANSFORM | ETL | Medium | 1/3 | 120 | 120 | dbt and transformation jobs |
+| INTERACTIVE | INTERACTIVE | Small | 1/2 | 300 | 30 | Analyst queries |
+| REPORTING | REPORTING | Medium | 1/4 | 300 | 60 | BI tool queries |
 
 **Sizing Guidelines:**
 - X-Small/Small: Development, light queries

--- a/blueprints/data-product-setup/transfer-ownership-wire-hierarchy/overview.md
+++ b/blueprints/data-product-setup/transfer-ownership-wire-hierarchy/overview.md
@@ -222,30 +222,19 @@ For environment-based and domain+environment strategies, select the environment 
 
 #### Define the schemas for each zone in your data product. (`schema_configuration`: object-list)
 **What is this asking?**
-Define schemas within each zone. Schemas organize tables by source system 
-or subject area.
+Define schemas for each zone in your data product. Each row represents one zone, and `schemas` is a comma-separated list of schema names that belong to that zone.
 
 **Example Configuration:**
 
-**RAW Zone:**
-| Schema | Purpose |
-|--------|---------|
-| SALESFORCE | Salesforce CRM data |
-| SAP | SAP ERP data |
-| STRIPE | Payment processing data |
+| Zone | Schemas |
+|------|---------|
+| RAW | SALESFORCE, SAP, STRIPE |
+| CURATED | CUSTOMERS, ORDERS, PRODUCTS |
+| CONSUMPTION | REPORTING, ANALYTICS |
 
-**CURATED Zone:**
-| Schema | Purpose |
-|--------|---------|
-| CUSTOMERS | Unified customer data |
-| ORDERS | Order history |
-| PRODUCTS | Product catalog |
-
-**CONSUMPTION Zone:**
-| Schema | Purpose |
-|--------|---------|
-| REPORTING | BI-ready tables |
-| ANALYTICS | Aggregations and metrics |
+**Field Descriptions:**
+- **zone**: The data zone this entry applies to (e.g. RAW, CURATED, CONSUMPTION). Must match a zone defined in your data architecture.
+- **schemas**: Comma-separated list of schema names for this zone (e.g. `SALESFORCE, SAP, STRIPE`). Each schema name should be uppercase and contain only letters, numbers, and underscores.
 
 **Best Practices:**
 - Use consistent naming across zones

--- a/blueprints/platform-foundation-setup/configure-scim-integration/code.sql.jinja
+++ b/blueprints/platform-foundation-setup/configure-scim-integration/code.sql.jinja
@@ -24,9 +24,11 @@ GRANT CREATE ROLE ON ACCOUNT TO ROLE {{ scim_provisioner_role | upper }};
 GRANT ROLE {{ scim_provisioner_role | upper }} TO ROLE ACCOUNTADMIN;
 
 -- ============================================================================
--- STEP 2: CREATE NETWORK RULE FOR SCIM
+-- STEP 2: CREATE NETWORK RULE AND POLICY FOR SCIM (if IPs provided)
 -- ============================================================================
 -- Restrict SCIM API access to your IdP's IP addresses
+
+{%- if scim_allowed_ips | length > 0 %}
 
 CREATE OR REPLACE NETWORK RULE scim_network_rule
   TYPE = IPV4
@@ -46,6 +48,8 @@ CREATE OR REPLACE NETWORK POLICY scim_network_policy
   ALLOWED_NETWORK_RULE_LIST = (scim_network_rule)
   COMMENT = 'Network policy for {{ identity_provider }} SCIM integration';
 
+{%- endif %}
+
 -- ============================================================================
 -- STEP 4: CREATE SCIM SECURITY INTEGRATION
 -- ============================================================================
@@ -55,7 +59,9 @@ CREATE OR REPLACE SECURITY INTEGRATION {{ scim_integration_name | upper }}
   TYPE = SCIM
   SCIM_CLIENT = 'OKTA'
   RUN_AS_ROLE = '{{ scim_provisioner_role | upper }}'
+{%- if scim_allowed_ips | length > 0 %}
   NETWORK_POLICY = 'scim_network_policy'
+{%- endif %}
   SYNC_PASSWORD = FALSE
   COMMENT = 'Okta SCIM integration for user provisioning';
 {%- elif identity_provider == "Microsoft Entra ID (Azure AD)" %}
@@ -63,7 +69,9 @@ CREATE OR REPLACE SECURITY INTEGRATION {{ scim_integration_name | upper }}
   TYPE = SCIM
   SCIM_CLIENT = 'AZURE'
   RUN_AS_ROLE = '{{ scim_provisioner_role | upper }}'
+{%- if scim_allowed_ips | length > 0 %}
   NETWORK_POLICY = 'scim_network_policy'
+{%- endif %}
   SYNC_PASSWORD = FALSE
   COMMENT = 'Azure AD SCIM integration for user provisioning';
 {%- else %}
@@ -71,7 +79,9 @@ CREATE OR REPLACE SECURITY INTEGRATION {{ scim_integration_name | upper }}
   TYPE = SCIM
   SCIM_CLIENT = 'GENERIC'
   RUN_AS_ROLE = '{{ scim_provisioner_role | upper }}'
+{%- if scim_allowed_ips | length > 0 %}
   NETWORK_POLICY = 'scim_network_policy'
+{%- endif %}
   SYNC_PASSWORD = FALSE
   COMMENT = '{{ identity_provider }} SCIM integration for user provisioning';
 {%- endif %}
@@ -96,8 +106,11 @@ https://{{ snowflake_org_name | lower }}-{% if account_name_prefix | upper != "N
 -- Verify the role was created
 SHOW ROLES LIKE '{{ scim_provisioner_role | upper }}';
 
+{%- if scim_allowed_ips | length > 0 %}
+
 -- Verify the network policy was created
 SHOW NETWORK POLICIES LIKE 'scim_network_policy';
+{%- endif %}
 
 -- Verify the security integration was created
 SHOW SECURITY INTEGRATIONS LIKE '{{ scim_integration_name | upper }}';

--- a/blueprints/platform-foundation-setup/configure-scim-integration/dynamic.md.jinja
+++ b/blueprints/platform-foundation-setup/configure-scim-integration/dynamic.md.jinja
@@ -10,13 +10,27 @@
 
 ### SCIM Network Policy
 
-The following IP addresses will be allowed to access the SCIM API:
+{%- if scim_allowed_ips | length > 0 %}
+
+A network policy will be created to restrict SCIM access to these IP addresses:
 
 | IP Address/CIDR |
 |-----------------|
 {%- for ip in scim_allowed_ips %}
 | `{{ ip }}` |
 {%- endfor %}
+
+{%- if identity_provider in ["Microsoft Entra ID (Azure AD)", "Okta"] %}
+
+> **Note:** {{ identity_provider }} outbound IP addresses change over time (Azure AD: weekly; Okta: unpredictably). This static list will require periodic maintenance to avoid SCIM provisioning failures. The SCIM bearer token alone is sufficient for authentication — consider removing these IPs to reduce operational overhead.
+
+{%- endif %}
+
+{%- else %}
+
+No SCIM network policy will be created. The SCIM bearer token provides sufficient authentication.{% if identity_provider in ["Microsoft Entra ID (Azure AD)", "Okta"] %} For {{ identity_provider }}, this is the recommended approach — their outbound IP addresses change over time, making static IP lists difficult to maintain reliably.{% endif %}
+
+{%- endif %}
 
 ### SCIM Endpoint URL
 

--- a/blueprints/platform-foundation-setup/configure-scim-integration/overview.md
+++ b/blueprints/platform-foundation-setup/configure-scim-integration/overview.md
@@ -111,20 +111,21 @@ Use the IdP-specific role name if available, as this follows Snowflake's documen
 
 #### What IP addresses should be allowed to access the SCIM API? (`scim_allowed_ips`: list)
 **What is this asking?**
-Provide the IP addresses or CIDR blocks that your Identity Provider uses for SCIM provisioning requests.
+Provide the IP addresses or CIDR blocks that your Identity Provider uses for SCIM provisioning requests. This creates a network policy that restricts SCIM API access to those IPs.
 
-**Why does this matter?**
-A network policy restricts SCIM API access to only your IdP's servers. This prevents unauthorized systems from creating or modifying users in Snowflake.
+**Recommendation for Azure AD and Okta: leave this empty.**
+Azure AD (Entra ID) IP addresses change on a weekly schedule and Okta IPs change unpredictably — a static IP list will drift out of date and break SCIM provisioning. The SCIM bearer token is the primary authentication mechanism and is sufficient on its own. Skipping the network policy avoids ongoing maintenance burden without meaningfully reducing security.
+Only provide IPs if your IdP uses a stable, known set of outbound addresses (e.g. on-premises or private-network IdPs).
 
-**How to find your IdP's IP addresses:**
+**How to find your IdP's IP addresses (if needed):**
 
 **Okta:**
 - Visit [Okta IP Ranges](https://help.okta.com/en/prod/Content/Topics/Security/ip-address-allow-listing.htm)
-- Use the ranges for your Okta cell (find your cell at `Settings > Account`)
+- Use the ranges for your Okta cell only (find your cell at `Settings > Account`); note these change without notice
 
 **Microsoft Entra ID (Azure AD):**
-- Visit [Azure IP Ranges](https://www.microsoft.com/en-us/download/details.aspx?id=56519)
-- Look for "AzureActiveDirectory" service tag
+- Visit [Azure Service Tags](https://www.microsoft.com/en-us/download/details.aspx?id=56519)
+- Look for the "AzureActiveDirectory" service tag; updated weekly by Microsoft
 - Filter for your region
 
 **Other IdPs:**

--- a/definitions/questions.yaml
+++ b/definitions/questions.yaml
@@ -1134,6 +1134,7 @@
   - email
   - first_name
   - last_name
+  - user_identifier
   guidance: '**What is this asking?**
 
     Define the users who need administrator privileges in this account.
@@ -1176,6 +1177,11 @@
 
     - **admin_role**: The administrative role to assign
 
+    - **user_identifier** *(optional)*: The exact Snowflake username to use when granting roles. If your IdP
+      provisions usernames differently from `login_name` (e.g., Snowflake stores `JOHN.DOE@COMPANY.COM` but
+      `login_name` was entered as `john.doe@company.com`), set this to the value shown in `SHOW USERS;`. Falls
+      back to `login_name` if not provided.
+
 
     Leave `email`, `first_name`, and `last_name` blank for SCIM users—these are managed by your IdP.
 
@@ -1193,6 +1199,10 @@
     - **first_name**: User''s first name
 
     - **last_name**: User''s last name
+
+    - **user_identifier** *(optional)*: Override the identifier used in `CREATE USER` and `GRANT ROLE`
+      statements. Useful when the desired Snowflake username contains `@` or `.` and needs to be quoted,
+      or differs from the login name. Falls back to `login_name` if not provided.
 
 
     **Admin Role Options:**
@@ -1236,7 +1246,18 @@
   guidance: '**What is this asking?**
 
     Enter the IP addresses from which your Identity Provider will make SCIM API calls to Snowflake. This
-    creates a network policy that restricts SCIM access.
+    creates a network policy that restricts SCIM access to those IPs.
+
+
+    **Recommendation for Azure AD and Okta: leave this empty.**
+
+    Azure AD (Entra ID) IP addresses change on a weekly schedule and Okta IPs change unpredictably — a
+    static IP list will drift out of date and break SCIM provisioning. The SCIM bearer token is the
+    primary authentication mechanism and is sufficient on its own. Skipping the network policy avoids
+    ongoing maintenance burden without meaningfully reducing security.
+
+    Only provide IPs if your IdP uses a stable, known set of outbound addresses (e.g. on-premises
+    or private-network IdPs).
 
 
     **If using Organization Configuration:**
@@ -1244,16 +1265,13 @@
     Use the same IdP IP addresses as your Organization Account for consistency.
 
 
-    **Why does this matter?**
+    **How to find your IdP''s IP ranges (if needed):**
 
-    Restricting SCIM access to known IdP IPs prevents unauthorized provisioning attempts.
+    - **Okta**: [Okta IP Ranges](https://help.okta.com/en-us/Content/Topics/Security/IP-Ranges.htm)
+    — use the ranges for your Okta cell only; note these change without notice
 
-
-    **How to find your IdP''s IP ranges:**
-
-    - **Okta**: [Okta IP Addresses](https://help.okta.com/en-us/Content/Topics/Security/IP-Ranges.htm)
-
-    - **Azure AD**: [Azure AD IP Ranges](https://docs.microsoft.com/en-us/azure/active-directory/enterprise-users/directory-service-limits-restrictions)
+    - **Azure AD**: [Azure Service Tags](https://www.microsoft.com/en-us/download/details.aspx?id=56519)
+    — look for the AzureActiveDirectory tag; updated weekly by Microsoft
 
 
     **Format:**
@@ -1267,10 +1285,6 @@
     198.51.100.1
 
     ```
-
-
-    **Important:** If you don''t know your IdP''s IP ranges, you can skip the network policy and add it
-    later. However, this is a security best practice.
 
 
     **More Information:**
@@ -3088,29 +3102,36 @@
   guidance: '**What is this asking?**
 
     Provide the IP addresses or CIDR blocks that your Identity Provider uses for SCIM provisioning requests.
+    This creates a network policy that restricts SCIM API access to those IPs.
 
 
-    **Why does this matter?**
+    **Recommendation for Azure AD and Okta: leave this empty.**
 
-    A network policy restricts SCIM API access to only your IdP''s servers. This prevents unauthorized
-    systems from creating or modifying users in Snowflake.
+    Azure AD (Entra ID) IP addresses change on a weekly schedule and Okta IPs change unpredictably — a
+    static IP list will drift out of date and break SCIM provisioning. The SCIM bearer token is the
+    primary authentication mechanism and is sufficient on its own. Skipping the network policy avoids
+    ongoing maintenance burden without meaningfully reducing security.
+
+    Only provide IPs if your IdP uses a stable, known set of outbound addresses (e.g. on-premises
+    or private-network IdPs).
 
 
-    **How to find your IdP''s IP addresses:**
+    **How to find your IdP''s IP addresses (if needed):**
 
 
     **Okta:**
 
     - Visit [Okta IP Ranges](https://help.okta.com/en/prod/Content/Topics/Security/ip-address-allow-listing.htm)
 
-    - Use the ranges for your Okta cell (find your cell at `Settings > Account`)
+    - Use the ranges for your Okta cell only (find your cell at `Settings > Account`); note these change
+    without notice
 
 
     **Microsoft Entra ID (Azure AD):**
 
-    - Visit [Azure IP Ranges](https://www.microsoft.com/en-us/download/details.aspx?id=56519)
+    - Visit [Azure Service Tags](https://www.microsoft.com/en-us/download/details.aspx?id=56519)
 
-    - Look for "AzureActiveDirectory" service tag
+    - Look for the "AzureActiveDirectory" service tag; updated weekly by Microsoft
 
     - Filter for your region
 
@@ -3941,16 +3962,17 @@
   object_name: Schema Configuration
   keys:
   - zone
-  - schema_name
-  - purpose
-  guidance: "**What is this asking?**\nDefine schemas within each zone. Schemas organize tables by source\
-    \ system \nor subject area.\n\n**Example Configuration:**\n\n**RAW Zone:**\n| Schema | Purpose |\n\
-    |--------|---------|\n| SALESFORCE | Salesforce CRM data |\n| SAP | SAP ERP data |\n| STRIPE | Payment\
-    \ processing data |\n\n**CURATED Zone:**\n| Schema | Purpose |\n|--------|---------|\n| CUSTOMERS\
-    \ | Unified customer data |\n| ORDERS | Order history |\n| PRODUCTS | Product catalog |\n\n**CONSUMPTION\
-    \ Zone:**\n| Schema | Purpose |\n|--------|---------|\n| REPORTING | BI-ready tables |\n| ANALYTICS\
-    \ | Aggregations and metrics |\n\n**Best Practices:**\n- Use consistent naming across zones\n- Group\
-    \ by source system in RAW, by subject in CURATED\n- Keep schema count manageable (2-5 per zone)\n"
+  - schemas
+  guidance: "**What is this asking?**\nDefine schemas for each zone in your data product. Each row\
+    \ represents one zone, and `schemas` is a comma-separated list of schema names that belong to\
+    \ that zone.\n\n**Example Configuration:**\n\n| Zone | Schemas |\n|------|---------|\n| RAW |\
+    \ SALESFORCE, SAP, STRIPE |\n| CURATED | CUSTOMERS, ORDERS, PRODUCTS |\n| CONSUMPTION | REPORTING,\
+    \ ANALYTICS |\n\n**Field Descriptions:**\n- **zone**: The data zone this entry applies to (e.g.\
+    \ RAW, CURATED, CONSUMPTION). Must match a zone defined in your data architecture.\n- **schemas**:\
+    \ Comma-separated list of schema names for this zone (e.g. `SALESFORCE, SAP, STRIPE`). Each\
+    \ schema name should be uppercase and contain only letters, numbers, and underscores.\n\n**Best\
+    \ Practices:**\n- Use consistent naming across zones\n- Group by source system in RAW, by subject\
+    \ in CURATED\n- Keep schema count manageable (2-5 per zone)\n"
 - answer_title: warehouse_configuration
   question_text: Define the warehouses for your data product.
   answer_type: object-list
@@ -3962,9 +3984,31 @@
   - min_cluster_count
   - max_cluster_count
   - auto_suspend_seconds
+  - workload
+  - timeout_minutes
+  - comment
   guidance: '**What is this asking?**
 
     Define compute warehouses for your data product workloads.
+
+
+    **Field Descriptions:**
+
+    - **name**: Short identifier used in Snowflake object names (e.g. `ETL` → `PREFIX_WH_ETL`). Uppercase,
+      no spaces.
+
+    - **workload**: Functional label describing the workload type (e.g. `ETL`, `ANALYTICS`, `INTERACTIVE`).
+      Used in planning summaries and warehouse tags.
+
+    - **size**: Warehouse size (X-Small, Small, Medium, Large, X-Large, 2X-Large).
+
+    - **min_cluster_count** / **max_cluster_count**: Multi-cluster range. Use 1/1 for single-cluster.
+
+    - **auto_suspend_seconds**: Seconds of inactivity before auto-suspend (60–600 recommended).
+
+    - **timeout_minutes**: Query timeout in minutes. Queries exceeding this are cancelled (e.g. `30`).
+
+    - **comment**: Human-readable description of the warehouse''s purpose.
 
 
     **Common Patterns:**
@@ -3972,37 +4016,37 @@
 
     **Simple (1 warehouse):**
 
-    | Name | Size | Min/Max Clusters | Auto-Suspend |
+    | Name | Workload | Size | Min/Max | Auto-Suspend | Timeout (min) | Comment |
 
-    |------|------|------------------|--------------|
+    |------|----------|------|---------|--------------|---------------|---------|
 
-    | GENERAL | Small | 1/1 | 300 |
+    | GENERAL | GENERAL | Small | 1/1 | 300 | 30 | General purpose warehouse |
 
 
     **Standard (2-3 warehouses):**
 
-    | Name | Size | Min/Max Clusters | Auto-Suspend |
+    | Name | Workload | Size | Min/Max | Auto-Suspend | Timeout (min) | Comment |
 
-    |------|------|------------------|--------------|
+    |------|----------|------|---------|--------------|---------------|---------|
 
-    | ETL | Medium | 1/3 | 60 |
+    | ETL | ETL | Medium | 1/3 | 60 | 120 | Batch ingestion and transformation |
 
-    | QUERY | Small | 1/2 | 300 |
+    | QUERY | INTERACTIVE | Small | 1/2 | 300 | 30 | Ad-hoc and BI queries |
 
 
     **Advanced (workload isolation):**
 
-    | Name | Size | Min/Max Clusters | Auto-Suspend |
+    | Name | Workload | Size | Min/Max | Auto-Suspend | Timeout (min) | Comment |
 
-    |------|------|------------------|--------------|
+    |------|----------|------|---------|--------------|---------------|---------|
 
-    | INGEST | Large | 1/3 | 60 |
+    | INGEST | INGEST | Large | 1/3 | 60 | 240 | High-volume data loading |
 
-    | TRANSFORM | Medium | 1/3 | 120 |
+    | TRANSFORM | ETL | Medium | 1/3 | 120 | 120 | dbt and transformation jobs |
 
-    | INTERACTIVE | Small | 1/2 | 300 |
+    | INTERACTIVE | INTERACTIVE | Small | 1/2 | 300 | 30 | Analyst queries |
 
-    | REPORTING | Medium | 1/4 | 300 |
+    | REPORTING | REPORTING | Medium | 1/4 | 300 | 60 | BI tool queries |
 
 
     **Sizing Guidelines:**


### PR DESCRIPTION
## Summary

Synced from [blueprint-manager-core PR #26](https://github.com/Snowflake-Labs/blueprint-manager-core/pull/26).

**SCIM integration:**
- Network rule and policy creation is now conditional — only created when `scim_allowed_ips` is provided; `NETWORK_POLICY` is omitted from the security integration when no IPs are configured
- Updated guidance to clarify that skipping the network policy is acceptable when IdP IPs are not stable (Okta/Azure AD)

**Question definitions (`definitions/questions.yaml`):**
- `account_admin_users`: added optional `user_identifier` key for cases where the Snowflake username differs from `login_name` after SCIM provisioning
- `schema_configuration`: replaced unused `schema_name`/`purpose` keys with `schemas` (comma-separated list per zone); rewrote guidance to match the one-row-per-zone model all templates use
- `warehouse_configuration`: added `workload`, `timeout_minutes`, `comment` keys; expanded guidance with field descriptions and updated examples

## Test plan
- [ ] Verify SCIM integration step renders correctly with and without `scim_allowed_ips`
- [ ] Verify schema configuration question displays with `zone` and `schemas` fields
- [ ] Verify warehouse configuration question displays all 8 fields

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)