### PR TITLE
Content update: QUERY_TAG step tracking, auth-policy DB context, cost-tag fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,60 @@ python scripts/render_journey.py \
 
 Review the generated SQL file, then execute it in your Snowflake worksheet. The SQL is idempotent — safe to run multiple times.
 
+## Step-level Implementation Tracking (QUERY_TAG)
+
+Rendered SQL journeys are automatically annotated with Snowflake
+`QUERY_TAG`s so that execution of Blueprint-generated SQL can be detected
+in query history. This is applied **only to SQL output**; Terraform output
+is unaffected.
+
+For every rendered step the renderer wraps the step's SQL with a
+matching SET/UNSET pair:
+
+```sql
+ALTER SESSION SET QUERY_TAG = '{"src":"blueprints","bp":"<blueprint_id>","step":"<step_slug>"}';
+-- ... step SQL ...
+ALTER SESSION UNSET QUERY_TAG;
+```
+
+so each step's tag is scoped to just that step's queries and does not
+bleed into unrelated queries the customer runs later in the same
+session.
+
+### Tag schema
+
+The tag value is a compact single-line JSON object with exactly these
+keys (total payload is kept well under Snowflake's 2 KB `QUERY_TAG`
+limit):
+
+| key    | meaning                                               |
+|--------|-------------------------------------------------------|
+| `src`  | source identifier, always `"blueprints"` for this repo |
+| `bp`   | blueprint identifier (from `meta.yaml` `blueprint_id`, falling back to blueprint directory name) |
+| `step` | step identifier (step slug) within the blueprint       |
+
+> `run_id` is intentionally **not** included. Chronological ordering in
+> query history is sufficient for the current analysis. If per-run
+> attribution is later required it can be added as an additional short
+> key.
+
+### Querying executions
+
+To find Blueprint-executed steps in the usual job/query-history views,
+use the `TAG` column (e.g. `job_etl_v` / `CXE_JOB_RAW_V_LAST_90`):
+
+```sql
+SELECT TAG:bp::string   AS blueprint,
+       TAG:step::string AS step,
+       COUNT(*)         AS n
+FROM   job_etl_v
+WHERE  TAG:src::string = 'blueprints'
+GROUP  BY 1, 2;
+```
+
+Because `QUERY_TAG` lands in a dedicated `TAG` column, these queries do
+not require `LIKE` / `ILIKE` scans over SQL text.
+
 License
 Copyright (c) 2026 Snowflake Inc. All rights reserved.
 This repo is source-available and licensed under these [terms](/LICENSE).

--- a/blueprints/platform-foundation-setup/configure-authentication-policies/code.sql.jinja
+++ b/blueprints/platform-foundation-setup/configure-authentication-policies/code.sql.jinja
@@ -5,6 +5,7 @@
 -- ============================================================================
 
 USE ROLE ACCOUNTADMIN;
+USE DATABASE {{ platform_database_name | upper }};
 
 -- ============================================================================
 -- STEP 1: CREATE HUMAN USER AUTHENTICATION POLICY

--- a/blueprints/platform-foundation-setup/configure-authentication-policies/overview.md
+++ b/blueprints/platform-foundation-setup/configure-authentication-policies/overview.md
@@ -56,6 +56,23 @@ Without proper authentication policies:
 
 ### Configuration Questions
 
+#### What do you want to name the platform database? (`platform_database_name`: text)
+**What is the Platform/Infrastructure Database?**  
+  The Infrastructure Database is a centralized "hub" database that houses platform-wide objects including tags, network rules, governance policies, and shared procedures. It is owned by the central platform team and shared across all accounts in multi-account deployments.  
+  **Recommended Naming Approach:**  
+  Use a name that clearly identifies this as a platform-owned, infrastructure-focused database. The format should be: \<domain\>\_\<dataproduct\>  
+  * **Domain:** Use plat (short for "platform") or your platform team's acronym (e.g., cdp, snow, data)  
+  * **Data Product:** Use infra or another term indicating infrastructure purpose  
+* **Example:** PLAT\_INFRA — clearly indicates Platform team ownership and Infrastructure purpose  
+  **Alternative Examples:**  
+  * CDP\_INFRA — Cloud Data Platform Infrastructure  
+  * SNOW\_ADMIN — Snowflake Administration  
+  * DATA\_PLATFORM — Data Platform database  
+* **Important:** Choose carefully\! This name will eventually be referenced by dozens to hundreds of objects, policies, and procedures. Changing it later can be complex and risky.  
+  **More Information:**  
+  * [CREATE DATABASE](https://docs.snowflake.com/en/sql-reference/sql/create-database)  
+  * [Object Identifiers](https://docs.snowflake.com/en/sql-reference/identifiers)
+
 #### What authentication methods should be allowed for human users in this account? (`human_auth_methods`: multi-select)
 **What is this asking?**
 Choose how human users (interactive users) should authenticate to this account. The value from Platform Foundation is pre-populated—accept it for consistency or change it if this account has different requirements.

--- a/blueprints/platform-foundation-setup/configure-cost-allocation-tags/code.sql.jinja
+++ b/blueprints/platform-foundation-setup/configure-cost-allocation-tags/code.sql.jinja
@@ -48,7 +48,7 @@ JOIN snowflake.account_usage.tag_references tr
   ON wm.warehouse_name = tr.object_name
   AND tr.domain = 'WAREHOUSE'
   AND tr.tag_name = 'DOMAIN'
-  AND tr.deleted_on IS NULL
+  AND tr.object_deleted IS NULL
 WHERE wm.start_time >= DATEADD(day, -30, CURRENT_TIMESTAMP())
 GROUP BY tr.tag_value, DATE_TRUNC('day', wm.start_time)
 ORDER BY usage_date DESC, total_credits DESC;
@@ -64,7 +64,7 @@ JOIN snowflake.account_usage.tag_references tr
   ON wm.warehouse_name = tr.object_name
   AND tr.domain = 'WAREHOUSE'
   AND tr.tag_name = 'ENVIRONMENT'
-  AND tr.deleted_on IS NULL
+  AND tr.object_deleted IS NULL
 WHERE wm.start_time >= DATEADD(day, -30, CURRENT_TIMESTAMP())
 GROUP BY tr.tag_value, DATE_TRUNC('day', wm.start_time)
 ORDER BY usage_date DESC, total_credits DESC;
@@ -79,7 +79,7 @@ FROM snowflake.account_usage.warehouses w
 LEFT JOIN (
   SELECT DISTINCT object_name 
   FROM snowflake.account_usage.tag_references 
-  WHERE tag_name = 'DOMAIN' AND domain = 'WAREHOUSE' AND deleted_on IS NULL
+  WHERE tag_name = 'DOMAIN' AND domain = 'WAREHOUSE' AND object_deleted IS NULL
 ) d ON w.name = d.object_name
 WHERE w.deleted IS NULL
   AND d.object_name IS NULL
@@ -94,8 +94,10 @@ GRANT SELECT ON VIEW untagged_warehouses TO ROLE SYSADMIN;
 -- STEP 3: TAG THE INFRASTRUCTURE DATABASE
 -- ============================================================================
 
+{%- if "Owner" in additional_tag_dimensions %}
 ALTER DATABASE {{ platform_database_name | upper }} SET TAG 
   {{ platform_database_name | upper }}.{{ governance_name | upper }}.owner = 'Platform Team';
+{%- endif %}
 
 -- ============================================================================
 -- VERIFICATION

--- a/scripts/render_journey.py
+++ b/scripts/render_journey.py
@@ -16,6 +16,7 @@ Steps with missing variables are skipped entirely.
 """
 
 import argparse
+import json
 import re
 import sys
 from datetime import datetime
@@ -97,6 +98,45 @@ class NullTracker:
 
 
 DEFAULT_PROJECT_NAME = "default-project"
+
+# QUERY_TAG constants: tag rendered SQL with {src, bp, step} so step
+# execution can be attributed in Snowflake query history.
+QUERY_TAG_SOURCE = "blueprints"
+QUERY_TAG_MAX_BYTES = 2000  # Snowflake QUERY_TAG hard limit.
+QUERY_TAG_MAX_VALUE_CHARS = 200  # Per-value cap keeps payload under the budget.
+
+
+def _coerce_tag_value(value):
+    """Stringify and truncate a QUERY_TAG field; ``None`` becomes ``""``."""
+    if value is None:
+        return ""
+    return str(value)[:QUERY_TAG_MAX_VALUE_CHARS]
+
+
+def build_query_tag_payload(blueprint, step, source=QUERY_TAG_SOURCE):
+    """Build the compact JSON payload used as the Snowflake QUERY_TAG value."""
+    payload = {
+        "src": _coerce_tag_value(source),
+        "bp": _coerce_tag_value(blueprint),
+        "step": _coerce_tag_value(step),
+    }
+    return json.dumps(payload, separators=(",", ":"), ensure_ascii=True)
+
+
+def _escape_sql_single_quotes(value):
+    """Escape single quotes for use inside a SQL single-quoted string literal."""
+    return value.replace("'", "''")
+
+
+def render_set_query_tag_sql(blueprint, step, source=QUERY_TAG_SOURCE):
+    """Render ``ALTER SESSION SET QUERY_TAG = '<json>';`` for the given blueprint/step."""
+    payload = build_query_tag_payload(blueprint, step, source=source)
+    return f"ALTER SESSION SET QUERY_TAG = '{_escape_sql_single_quotes(payload)}';"
+
+
+def render_unset_query_tag_sql():
+    """Render the statement that clears the session QUERY_TAG."""
+    return "ALTER SESSION UNSET QUERY_TAG;"
 
 
 def classify_missing_vars(missing_vars, answers):
@@ -872,6 +912,12 @@ def render_blueprint_code(blueprint_dir, lang, answers, base_dir, blueprint_meta
     Only renders steps where all required variables are available.
     Steps with missing variables include a skip note in the output.
     Returns the concatenated rendered code and count of rendered/skipped steps.
+
+    For SQL output, each rendered step is wrapped with
+    ``ALTER SESSION SET QUERY_TAG`` before the step's SQL and
+    ``ALTER SESSION UNSET QUERY_TAG`` after it, so the step's queries can be
+    attributed in Snowflake query history without the tag leaking to queries
+    outside the step.
     
     Args:
         blueprint_dir: Path to the blueprint directory
@@ -895,6 +941,12 @@ def render_blueprint_code(blueprint_dir, lang, answers, base_dir, blueprint_meta
         raise ValueError(f"blueprint_meta must be a dict, got {type(blueprint_meta).__name__}")
     blueprint_name = blueprint_meta.get("name", blueprint_id)
     step_order = blueprint_meta.get("steps", [])
+
+    # Prefer meta.yaml's stable blueprint_id; fall back to the directory name.
+    blueprint_tag_id = blueprint_meta.get("blueprint_id") or blueprint_id
+
+    # QUERY_TAG tracking is SQL-only.
+    inject_query_tags = (lang == "sql")
 
     # Create Jinja2 environment once for all steps
     jinja_env = create_jinja_env(base_dir)
@@ -1037,7 +1089,24 @@ def render_blueprint_code(blueprint_dir, lang, answers, base_dir, blueprint_meta
             "",
         ]
         rendered_sections.append("\n".join(step_header))
+        if inject_query_tags:
+            rendered_sections.append(
+                render_set_query_tag_sql(blueprint_tag_id, step_id) + "\n"
+            )
         rendered_sections.append(rendered_code)
+        if inject_query_tags:
+            rendered_sections.append(
+                "\n".join(
+                    [
+                        "",
+                        f"{comment_char} ------------------------------------------------------------",
+                        f"{comment_char} End of step: clear QUERY_TAG.",
+                        f"{comment_char} ------------------------------------------------------------",
+                        render_unset_query_tag_sql(),
+                        "",
+                    ]
+                )
+            )
         rendered_count += 1
 
     return "\n".join(rendered_sections), rendered_count, skipped_count

--- a/scripts/test_render_journey.py
+++ b/scripts/test_render_journey.py
@@ -2586,5 +2586,280 @@ class TestTocToHeadingAnchorConsistency(BlueprintTestCase):
         self.assertEqual(step_anchors[1], generate_anchor("Step 1.2: Set Up Roles"))
 
 
+class TestQueryTagPayload(TestCase):
+    """Unit tests for the QUERY_TAG payload helper."""
+
+    def test_payload_contains_exact_key_set(self):
+        """Payload must contain exactly src, bp, step — and no run_id."""
+        import json as _json
+        from render_journey import build_query_tag_payload
+
+        payload = build_query_tag_payload("bp-1", "step-a")
+        obj = _json.loads(payload)
+        self.assertEqual(set(obj.keys()), {"src", "bp", "step"})
+        self.assertNotIn("run_id", obj)
+
+    def test_payload_values_are_as_expected(self):
+        """src defaults to 'blueprints' and other fields pass through."""
+        import json as _json
+        from render_journey import build_query_tag_payload
+
+        obj = _json.loads(build_query_tag_payload("bp-1", "step-a"))
+        self.assertEqual(obj, {
+            "src": "blueprints",
+            "bp": "bp-1",
+            "step": "step-a",
+        })
+
+    def test_payload_is_single_line(self):
+        """Payload must be single-line JSON safe to embed in SQL."""
+        from render_journey import build_query_tag_payload
+
+        payload = build_query_tag_payload("bp-1", "step-a")
+        self.assertNotIn("\n", payload)
+        self.assertNotIn("\r", payload)
+
+    def test_payload_is_valid_json(self):
+        """Payload must parse as valid JSON."""
+        import json as _json
+        from render_journey import build_query_tag_payload
+
+        payload = build_query_tag_payload("bp-1", "step-a")
+        # Should not raise
+        _json.loads(payload)
+
+    def test_payload_under_2kb_budget(self):
+        """Tag payload must stay well below Snowflake's 2 KB QUERY_TAG limit."""
+        from render_journey import build_query_tag_payload, QUERY_TAG_MAX_BYTES
+
+        payload = build_query_tag_payload(
+            "some-long-blueprint-name", "some-long-step-slug"
+        )
+        self.assertLess(len(payload.encode("utf-8")), QUERY_TAG_MAX_BYTES)
+
+    def test_payload_over_budget_truncates_instead_of_raising(self):
+        """Oversized inputs are truncated per-value so rendering is never blocked."""
+        import json as _json
+        from render_journey import (
+            build_query_tag_payload,
+            QUERY_TAG_MAX_BYTES,
+            QUERY_TAG_MAX_VALUE_CHARS,
+        )
+
+        # 2100-char strings would have blown the 2 KB budget before; now each
+        # value is capped at QUERY_TAG_MAX_VALUE_CHARS so build never raises.
+        huge = "x" * 2100
+        payload = build_query_tag_payload(huge, huge)
+
+        self.assertLess(len(payload.encode("utf-8")), QUERY_TAG_MAX_BYTES)
+        obj = _json.loads(payload)
+        for key in ("bp", "step"):
+            self.assertEqual(len(obj[key]), QUERY_TAG_MAX_VALUE_CHARS)
+            self.assertTrue(obj[key].startswith("x"))
+
+    def test_render_set_query_tag_sql_escapes_single_quotes(self):
+        """Single quotes in bp/step must be SQL-escaped by doubling."""
+        from render_journey import render_set_query_tag_sql
+
+        sql = render_set_query_tag_sql("bp'1", "step'a")
+        # The raw single quotes from the JSON payload must be doubled so the
+        # outer ALTER SESSION SET QUERY_TAG = '...' string is not broken.
+        # (Keys in the JSON don't contain single quotes; only our injected
+        # bp / step values do — and they should be doubled.)
+        self.assertIn("bp''1", sql)
+        self.assertIn("step''a", sql)
+        # Sanity: the statement still starts/ends the way we expect.
+        self.assertTrue(sql.startswith("ALTER SESSION SET QUERY_TAG = '"))
+        self.assertTrue(sql.endswith("';"))
+
+    def test_render_unset_query_tag_sql_shape(self):
+        """UNSET statement is a fixed, well-formed ALTER SESSION."""
+        from render_journey import render_unset_query_tag_sql
+
+        self.assertEqual(
+            render_unset_query_tag_sql(), "ALTER SESSION UNSET QUERY_TAG;"
+        )
+
+    def test_default_source_is_blueprints(self):
+        """src must default to 'blueprints'."""
+        import json as _json
+        from render_journey import build_query_tag_payload
+
+        obj = _json.loads(build_query_tag_payload("bp", "step"))
+        self.assertEqual(obj["src"], "blueprints")
+
+
+class TestQueryTagInjection(BlueprintTestCase):
+    """Snapshot-style tests: QUERY_TAG SET/UNSET injection in render_blueprint_code."""
+
+    def _make_blueprint(self, lang="sql", extra_meta=None):
+        """Create a 2-step blueprint on disk and return (blueprint_dir, meta)."""
+        blueprint_dir = self.base_dir / "test-blueprint"
+        blueprint_dir.mkdir(parents=True, exist_ok=True)
+
+        step1 = blueprint_dir / "step-1"
+        step1.mkdir(parents=True, exist_ok=True)
+        (step1 / f"code.{lang}.jinja").write_text("SELECT 1;")
+
+        step2 = blueprint_dir / "step-2"
+        step2.mkdir(parents=True, exist_ok=True)
+        (step2 / f"code.{lang}.jinja").write_text("SELECT 2;")
+
+        meta = {
+            "blueprint_id": "blueprint_test",
+            "name": "Test Blueprint",
+            "steps": ["step-1", "step-2"],
+        }
+        if extra_meta:
+            meta.update(extra_meta)
+
+        meta_file = blueprint_dir / "meta.yaml"
+        with open(meta_file, "w") as f:
+            yaml.dump(meta, f)
+
+        return blueprint_dir, meta
+
+    def test_sql_every_step_has_set_and_unset_query_tag(self):
+        """Every rendered SQL step must be wrapped by SET/UNSET QUERY_TAG."""
+        from render_journey import render_blueprint_code
+
+        blueprint_dir, meta = self._make_blueprint(lang="sql")
+
+        rendered, rendered_count, _ = render_blueprint_code(
+            blueprint_dir, "sql", {}, self.base_dir, meta,
+            date_display="2026-02-27 10:00:00",
+        )
+
+        self.assertEqual(rendered_count, 2)
+        # Both step IDs appear inside ALTER SESSION SET QUERY_TAG statements.
+        self.assertIn(
+            'ALTER SESSION SET QUERY_TAG = \'{"src":"blueprints",'
+            '"bp":"blueprint_test","step":"step-1"}\';',
+            rendered,
+        )
+        self.assertIn(
+            'ALTER SESSION SET QUERY_TAG = \'{"src":"blueprints",'
+            '"bp":"blueprint_test","step":"step-2"}\';',
+            rendered,
+        )
+        # One UNSET per rendered step (end of each step, not end of journey).
+        self.assertEqual(rendered.count("ALTER SESSION UNSET QUERY_TAG;"), 2)
+        # Each step SQL still appears after its tag.
+        self.assertIn("SELECT 1;", rendered)
+        self.assertIn("SELECT 2;", rendered)
+
+    def test_sql_unset_follows_each_step(self):
+        """Each rendered step emits its own UNSET QUERY_TAG after the SQL."""
+        from render_journey import render_blueprint_code
+
+        blueprint_dir, meta = self._make_blueprint(lang="sql")
+
+        rendered, _, _ = render_blueprint_code(
+            blueprint_dir, "sql", {}, self.base_dir, meta,
+            date_display="2026-02-27 10:00:00",
+        )
+
+        # One UNSET per step, not a single end-of-journey UNSET.
+        self.assertEqual(rendered.count("ALTER SESSION UNSET QUERY_TAG;"), 2)
+        # Comment label is "End of step", not "End of journey".
+        self.assertIn("End of step: clear QUERY_TAG.", rendered)
+        self.assertNotIn("End of journey: clear QUERY_TAG.", rendered)
+
+    def test_sql_set_precedes_step_sql(self):
+        """For each step, the SET statement appears before the step's SQL."""
+        from render_journey import render_blueprint_code
+
+        blueprint_dir, meta = self._make_blueprint(lang="sql")
+
+        rendered, _, _ = render_blueprint_code(
+            blueprint_dir, "sql", {}, self.base_dir, meta,
+            date_display="2026-02-27 10:00:00",
+        )
+
+        set_step1_pos = rendered.find('"step":"step-1"')
+        select1_pos = rendered.find("SELECT 1;")
+        set_step2_pos = rendered.find('"step":"step-2"')
+        select2_pos = rendered.find("SELECT 2;")
+
+        self.assertGreater(set_step1_pos, -1)
+        self.assertGreater(select1_pos, set_step1_pos)
+        self.assertGreater(set_step2_pos, select1_pos)
+        self.assertGreater(select2_pos, set_step2_pos)
+
+    def test_terraform_output_has_no_query_tag_statements(self):
+        """Non-SQL languages must not include any QUERY_TAG statements."""
+        from render_journey import render_blueprint_code
+
+        blueprint_dir, meta = self._make_blueprint(lang="terraform")
+
+        rendered, rendered_count, _ = render_blueprint_code(
+            blueprint_dir, "terraform", {}, self.base_dir, meta,
+            date_display="2026-02-27 10:00:00",
+        )
+
+        self.assertEqual(rendered_count, 2)
+        self.assertNotIn("ALTER SESSION SET QUERY_TAG", rendered)
+        self.assertNotIn("ALTER SESSION UNSET QUERY_TAG", rendered)
+
+    def test_no_rendered_steps_means_no_unset(self):
+        """If nothing rendered (all skipped), don't emit a stray UNSET."""
+        from render_journey import render_blueprint_code
+
+        blueprint_dir = self.base_dir / "test-blueprint-skip"
+        blueprint_dir.mkdir(parents=True, exist_ok=True)
+        step1 = blueprint_dir / "step-1"
+        step1.mkdir(parents=True, exist_ok=True)
+        # Template references a variable that won't be provided -> step skipped
+        (step1 / "code.sql.jinja").write_text("SELECT {{ missing_var }};")
+        meta = {
+            "blueprint_id": "blueprint_test",
+            "name": "Test Blueprint",
+            "steps": ["step-1"],
+        }
+        (blueprint_dir / "meta.yaml").write_text(yaml.dump(meta))
+
+        rendered, rendered_count, skipped_count = render_blueprint_code(
+            blueprint_dir, "sql", {}, self.base_dir, meta,
+            date_display="2026-02-27 10:00:00",
+        )
+
+        self.assertEqual(rendered_count, 0)
+        self.assertEqual(skipped_count, 1)
+        self.assertNotIn("ALTER SESSION SET QUERY_TAG", rendered)
+        self.assertNotIn("ALTER SESSION UNSET QUERY_TAG", rendered)
+
+    def test_step_sql_content_is_unchanged_by_injection(self):
+        """Injecting the tag wrappers must not modify the step SQL content itself."""
+        from render_journey import render_blueprint_code
+
+        blueprint_dir, meta = self._make_blueprint(lang="sql")
+
+        rendered, _, _ = render_blueprint_code(
+            blueprint_dir, "sql", {}, self.base_dir, meta,
+            date_display="2026-02-27 10:00:00",
+        )
+
+        # Full step SQL is preserved byte-for-byte.
+        self.assertIn("SELECT 1;", rendered)
+        self.assertIn("SELECT 2;", rendered)
+
+    def test_blueprint_id_falls_back_to_directory_name(self):
+        """If meta.yaml has no blueprint_id, fall back to the blueprint dir name."""
+        import json as _json
+        from render_journey import render_blueprint_code
+
+        blueprint_dir, meta = self._make_blueprint(lang="sql")
+        meta.pop("blueprint_id", None)
+        (blueprint_dir / "meta.yaml").write_text(yaml.dump(meta))
+
+        rendered, _, _ = render_blueprint_code(
+            blueprint_dir, "sql", {}, self.base_dir, meta,
+            date_display="2026-02-27 10:00:00",
+        )
+
+        # Directory name is "test-blueprint"
+        self.assertIn('"bp":"test-blueprint"', rendered)
+
+
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary

Content update merging `content-update-2026-05-04-2149-ada9968` into `main`.

## Changes

### Feature: Step-level QUERY_TAG tracking for rendered SQL (`scripts/render_journey.py`)
- Each rendered SQL step is now wrapped with `ALTER SESSION SET QUERY_TAG = '{"src":"blueprints","bp":"<blueprint_id>","step":"<step_slug>"}'` before the step and `ALTER SESSION UNSET QUERY_TAG;` after it, scoping the tag to just that step.
- Tag payload is compact single-line JSON with exactly three keys (`src`, `bp`, `step`); `run_id` intentionally omitted.
- Per-value truncation (200 chars) keeps payload well under Snowflake's 2 KB `QUERY_TAG` limit without ever blocking render.
- Single quotes in `bp`/`step` values are SQL-escaped (doubled) for safe embedding.
- Prefers `meta.yaml` `blueprint_id`, falls back to the blueprint directory name.
- SQL-only: Terraform output is unaffected.
- New helpers: `build_query_tag_payload`, `render_set_query_tag_sql`, `render_unset_query_tag_sql`.

### Tests (`scripts/test_render_journey.py`, +275 lines)
- `TestQueryTagPayload`: key set, default `src`, single-line JSON validity, 2 KB budget, oversized-input truncation, single-quote escaping, UNSET shape.
- `TestQueryTagInjection`: SET/UNSET wraps every SQL step, UNSET emitted per step (not end-of-journey), SET precedes step SQL, Terraform output has no tag statements, no rendered steps produces no stray UNSET, step SQL content unchanged by wrappers.

### Docs (`README.md`)
- New section "Step-level Implementation Tracking (QUERY_TAG)" documenting the wrapping behavior, tag schema table, and an example query against `job_etl_v` / `CXE_JOB_RAW_V_LAST_90` using the dedicated `TAG` column.

### Blueprint: `platform-foundation-setup/configure-authentication-policies`
- `code.sql.jinja`: added `USE DATABASE {{ platform_database_name | upper }};` after `USE ROLE ACCOUNTADMIN;` so policy DDL runs in the correct database context.
- `overview.md`: added new configuration question `platform_database_name` with naming guidance (domain + data product), examples (`PLAT_INFRA`, `CDP_INFRA`, etc.), and links to `CREATE DATABASE` / Object Identifiers docs.

### Blueprint: `platform-foundation-setup/configure-cost-allocation-tags/code.sql.jinja`
- Replaced deprecated `tag_references.deleted_on IS NULL` with `object_deleted IS NULL` in three places (per-domain usage view, per-environment usage view, untagged-warehouses view).
- Gated the `ALTER DATABASE ... SET TAG owner = 'Platform Team'` statement behind `{%- if "Owner" in additional_tag_dimensions %}` so it only runs when the Owner tag dimension is selected.

## Test plan
- [ ] `python -m unittest scripts/test_render_journey.py` passes (new `TestQueryTagPayload` and `TestQueryTagInjection` classes).
- [ ] Render a SQL journey and confirm each step is wrapped with `ALTER SESSION SET QUERY_TAG = '{...}';` ... `ALTER SESSION UNSET QUERY_TAG;`.
- [ ] Render a Terraform journey and confirm no `QUERY_TAG` statements appear.
- [ ] Execute the rendered auth-policy SQL and confirm `USE DATABASE` resolves before policy creation.
- [ ] Execute the rendered cost-allocation-tags SQL and confirm the `account_usage.tag_references` views compile against the current `object_deleted` column.
- [ ] Render cost-allocation-tags with and without `Owner` in `additional_tag_dimensions` and confirm the `ALTER DATABASE ... SET TAG owner` statement is gated correctly.