### PR TITLE
Content update: Fix invalid Snowflake functions and incorrect role usage

### DIFF
--- a/blueprints/data-product-setup/create-data-product-core-roles/code.sql.jinja
+++ b/blueprints/data-product-setup/create-data-product-core-roles/code.sql.jinja
@@ -123,14 +123,10 @@ GRANT ROLE _AR_APPLY_TAG TO ROLE {{ prefix }}_CREATE;
 SHOW ROLES LIKE '%{{ prefix }}%';
 
 -- Verify role hierarchy
-SELECT 
-  grantee_name AS child_role,
-  role AS parent_role,
-  granted_by
-FROM TABLE(INFORMATION_SCHEMA.ROLE_GRANTS())
-WHERE role LIKE '%{{ prefix }}%'
-   OR grantee_name LIKE '%{{ prefix }}%'
-ORDER BY parent_role, child_role;
+SHOW GRANTS OF ROLE {{ prefix }}_ADMIN;
+SHOW GRANTS OF ROLE {{ prefix }}_CREATE;
+SHOW GRANTS OF ROLE {{ prefix }}_RBAC;
+SHOW GRANTS TO ROLE {{ prefix }}_ADMIN;
 
 /*
 CORE ROLES CREATED

--- a/blueprints/platform-foundation-setup/create-infrastructure-database/code.sql.jinja
+++ b/blueprints/platform-foundation-setup/create-infrastructure-database/code.sql.jinja
@@ -5,7 +5,7 @@
 -- metadata, governance objects, and administrative resources
 -- ============================================================================
 
-USE ROLE ACCOUNTADMIN;
+USE ROLE SYSADMIN;
 
 -- ============================================================================
 -- STEP 1: CREATE INFRASTRUCTURE DATABASE

--- a/blueprints/platform-foundation-setup/enable-organization-account/code.sql.jinja
+++ b/blueprints/platform-foundation-setup/enable-organization-account/code.sql.jinja
@@ -25,8 +25,10 @@ USE ROLE ACCOUNTADMIN;
 SELECT CURRENT_ORGANIZATION_NAME() AS organization_name;
 
 -- Verify your account edition (must be Enterprise or higher)
+-- Note: Account edition is visible in Snowsight under Admin > Accounts,
+-- or via SHOW ORGANIZATION ACCOUNTS (requires ORGADMIN role).
 SELECT CURRENT_ACCOUNT() AS account,
-       SYSTEM$GET_ACCOUNT_EDITION() AS edition;
+       CURRENT_ORGANIZATION_NAME() AS organization_name;
 
 -- Check if ORGADMIN role exists (may not exist yet in all accounts)
 SHOW ROLES LIKE 'ORGADMIN';
@@ -64,10 +66,11 @@ enabling the Organization Account for seamless expansion.
 */
 
 -- Verify current account configuration for standalone operation
+-- Note: Account edition is visible in Snowsight under Admin > Accounts,
+-- or via SHOW ORGANIZATION ACCOUNTS (requires ORGADMIN role).
 SELECT 
   CURRENT_ACCOUNT() AS current_account,
   CURRENT_ACCOUNT_NAME() AS account_name,
-  CURRENT_ORGANIZATION_NAME() AS organization_name,
-  SYSTEM$GET_ACCOUNT_EDITION() AS edition;
+  CURRENT_ORGANIZATION_NAME() AS organization_name;
 
 {%- endif %}


### PR DESCRIPTION
## Summary

Content update merging `content-update-2026-05-07-1927-c1d3261` into `main`.

## Changes

### Blueprint: `platform-foundation-setup` — `enable-organization-account`
- `code.sql.jinja`: Remove `SYSTEM$GET_ACCOUNT_EDITION()` (non-existent function) from two SELECT statements. Replace with `CURRENT_ORGANIZATION_NAME()` and add guidance comments noting edition is available via Snowsight or `SHOW ORGANIZATION ACCOUNTS` (requires ORGADMIN).

### Blueprint: `platform-foundation-setup` — `create-infrastructure-database`
- `code.sql.jinja`: Change `USE ROLE ACCOUNTADMIN` → `USE ROLE SYSADMIN` per Snowflake best practices for object creation.

### Blueprint: `data-product-setup` — `create-data-product-core-roles`
- `code.sql.jinja`: Replace `FROM TABLE(INFORMATION_SCHEMA.ROLE_GRANTS())` (non-existent table function) with `SHOW GRANTS OF ROLE` / `SHOW GRANTS TO ROLE` statements for role hierarchy verification.

## Test plan
- [x] Confirm no references to `SYSTEM$GET_ACCOUNT_EDITION` remain in blueprint SQL
- [x] Confirm no references to `INFORMATION_SCHEMA.ROLE_GRANTS()` remain in blueprint SQL
- [x] Verify `create-infrastructure-database` uses `SYSADMIN` not `ACCOUNTADMIN`